### PR TITLE
Modify condition in MultiDimClosure function

### DIFF
--- a/src/StructUtils.jl
+++ b/src/StructUtils.jl
@@ -698,11 +698,11 @@ end
     StructUtils.discover_dims(style, ::Type{T}, source) -> Tuple
 
 Discover the dimensions for a fixed-size array type `T`. By default,
-delegates to `discover_dims(style, source)` to scan the source object.
+delegates to `discover_dims(style, source, ndims(T))` to scan the source object.
 Override for types where dimensions are encoded in the type itself
 (e.g. `StaticArrays.StaticArray`), avoiding the need to scan the source.
 """
-discover_dims(style, ::Type{T}, source) where {T} = discover_dims(style, source)
+discover_dims(style, ::Type{T}, source) where {T} = discover_dims(style, source, ndims(T))
 
 """
     StructUtils.arrayfromdata(::Type{T}, mem, dims::Tuple) -> T

--- a/src/StructUtils.jl
+++ b/src/StructUtils.jl
@@ -168,7 +168,7 @@ initialize(st::StructStyle, T::Type, @nospecialize(source)) =
 
 function initialize(st::StructStyle, ::Type{A}, source) where {A<:AbstractArray}
     if ndims(A) > 1
-        dims = discover_dims(st, source)
+        dims = discover_dims(st, source, ndims(A))
         return A(undef, dims)
     else
         return A(undef, 0)
@@ -679,12 +679,16 @@ end # VERSION < v"1.10"
 # "[[[1.0],[2.0]]]" => (1, 2, 1)
 # "[[[1.0,2.0]]]" => (2, 1, 1)
 # length of innermost array is 1st dim
-function discover_dims(style, x)
+function discover_dims(style, x, ndims::Int)
     @assert arraylike(style, x)
     len = applylength(x)
+    if ndims == 1
+        return (len,)
+    end
+
     ret = (
         applyeach(x) do _, v
-            return arraylike(style, v) ? EarlyReturn(discover_dims(style, v)) : EarlyReturn(())
+            return arraylike(style, v) ? EarlyReturn(discover_dims(style, v, ndims - 1)) : EarlyReturn(())
         end
     )::EarlyReturn
     return (ret.value..., len)

--- a/src/StructUtils.jl
+++ b/src/StructUtils.jl
@@ -725,7 +725,7 @@ end
 
 function (f::MultiDimClosure{S,A})(i::Int, val) where {S,A}
     f.dims[f.cur_dim[]] = i
-    if arraylike(f.style, val)
+    if arraylike(f.style, val) && f.cur_dim[] > 1
         f.cur_dim[] -= 1
         st = applyeach(f, f.style, val)
         f.cur_dim[] += 1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -288,6 +288,22 @@ end
     # fill slice [:, :, 2] from second slab [[3,4]]
     exp3[:, :, 2] = reshape([3,4], 2, 1)
     @test x3 == exp3
+
+    # Jagged nested vectors (Vector of Vectors)
+    jagged = [[1, 2], [3, 4, 5], [6]]
+    result = StructUtils.make(Vector{Vector{Int}}, jagged)
+    @test result == jagged
+
+    # Multi-dimensional case with jagged inner vectors
+    vv_jagged = [[[1, 2], [3]], [[4, 5, 6], [7, 8]]]
+    result_md = StructUtils.make(Array{Vector{Int}, 2}, vv_jagged)
+
+    md_jagged = Array{Vector{Int}}(undef, 2, 2)
+    md_jagged[1, 1] = [1, 2]
+    md_jagged[2, 1] = [3]
+    md_jagged[1, 2] = [4, 5, 6]
+    md_jagged[2, 2] = [7, 8]
+    @test result_md == md_jagged
 end
 
 @testset "@nonstruct macro" begin


### PR DESCRIPTION
For context, I am trying to load a `Array{Vector{Int64}, 4}` using JSON.jl, which relies on StructUtils.jl. The inner vector is jagged, i.e. not the same length for every element, so `Array{Int64, 5}` is not an option. Now, without this stop condition, the multidimensional array continues until `f.cur_dim[] == 0` and fails to set the dimension, unsurprisingly. With this condition it works flawlessly.

Full disclaimer, I don't know if this will have a major impact elsewhere, so please review this PR carefully. But it would be nice if loading vectors in multi-dim arrays worked. 