### PR TITLE
Fix docstring lookup and macro return values

### DIFF
--- a/src/StructUtils.jl
+++ b/src/StructUtils.jl
@@ -148,7 +148,9 @@ function fielddefaults end
 
 fielddefaults(::StructStyle, T::Type)::NamedTuple{(),Tuple{}} = (;)
 fielddefault(st::StructStyle, T::Type, key) = get(fielddefaults(st, T), key, nothing)
-@doc (@doc fielddefaults) fielddefault
+
+"See [`fielddefaults`](@ref)."
+fielddefault
 
 """
     StructUtils.initialize(::StructStyle, T, source) -> T

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -235,6 +235,8 @@ function parse_struct_def(kind, src, mod, expr)
         end
         generate_field_defaults_and_tags!(ret, T, fields)
     end
+    # Return the struct type for REPL friendliness (like Base.@kwdef)
+    push!(ret.args, T)
     return esc(ret)
 end
 


### PR DESCRIPTION
## Summary

- Replace dynamic `@doc (@doc fielddefaults) fielddefault` with static docstring reference to avoid PackageCompiler precompilation issues where `Base.Docs.meta` may be undefined (fixes #36)

- Make `@noarg`, `@kwarg`, `@defaults`, `@tags`, and `@nonstruct` macros return the struct type for REPL friendliness, matching `Base.@kwdef` behavior (fixes #33)

## Test plan

- [x] All existing tests pass
- [x] Verified macro returns struct type in REPL
- [x] Verified docstrings render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)