### PR TITLE
Add fixedsizearray trait and StaticArrays support

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -27,9 +27,9 @@ Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Measurements = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
+Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
-Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [targets]
 test = ["Dates", "Measurements", "StaticArrays", "StaticArraysCore", "Tables", "Test", "UUIDs"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,30 +1,35 @@
 name = "StructUtils"
 uuid = "ec057cc2-7a8d-4b58-b3b3-92acb9f63b42"
-version = "2.6.3"
+version = "2.7.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [weakdeps]
-Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 Measurements = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
+StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
+Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [extensions]
-StructUtilsTablesExt = ["Tables"]
 StructUtilsMeasurementsExt = ["Measurements"]
+StructUtilsStaticArraysCoreExt = ["StaticArraysCore"]
+StructUtilsTablesExt = ["Tables"]
 
 [compat]
-julia = "1.9"
-Tables = "1"
 Measurements = "2"
+StaticArraysCore = "1"
+Tables = "1"
+julia = "1.9"
 
 [extras]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Measurements = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [targets]
-test = ["Dates", "Measurements", "Tables", "Test", "UUIDs"]
+test = ["Dates", "Measurements", "StaticArrays", "StaticArraysCore", "Tables", "Test", "UUIDs"]

--- a/ext/StructUtilsStaticArraysCoreExt.jl
+++ b/ext/StructUtilsStaticArraysCoreExt.jl
@@ -8,7 +8,9 @@ StructUtils.fixedsizearray(::Type{<:StaticArray}) = true
 StructUtils.discover_dims(style, ::Type{<:StaticArray{S}}, source) where {S<:Tuple} =
     size_to_tuple(S)
 
-StructUtils.arrayfromdata(::Type{T}, mem::Memory, dims::Tuple) where {T<:StaticArray} =
-    T(Tuple(mem))
+if VERSION >= v"1.11"
+    StructUtils.arrayfromdata(::Type{T}, mem::Memory, dims::Tuple) where {T<:StaticArray} =
+        T(Tuple(mem))
+end
 
 end # module

--- a/ext/StructUtilsStaticArraysCoreExt.jl
+++ b/ext/StructUtilsStaticArraysCoreExt.jl
@@ -8,6 +8,9 @@ StructUtils.fixedsizearray(::Type{<:StaticArray}) = true
 StructUtils.discover_dims(style, ::Type{<:StaticArray{S}}, source) where {S<:Tuple} =
     size_to_tuple(S)
 
+StructUtils.arrayfromdata(::Type{T}, buf::Vector, dims::Tuple) where {T<:StaticArray} =
+    T(Tuple(buf))
+
 if VERSION >= v"1.11"
     StructUtils.arrayfromdata(::Type{T}, mem::Memory, dims::Tuple) where {T<:StaticArray} =
         T(Tuple(mem))

--- a/ext/StructUtilsStaticArraysCoreExt.jl
+++ b/ext/StructUtilsStaticArraysCoreExt.jl
@@ -1,0 +1,14 @@
+module StructUtilsStaticArraysCoreExt
+
+using StructUtils
+using StaticArraysCore: StaticArray, size_to_tuple
+
+StructUtils.fixedsizearray(::Type{<:StaticArray}) = true
+
+StructUtils.discover_dims(style, ::Type{<:StaticArray{S}}, source) where {S<:Tuple} =
+    size_to_tuple(S)
+
+StructUtils.arrayfromdata(::Type{T}, mem::Memory, dims::Tuple) where {T<:StaticArray} =
+    T(Tuple(mem))
+
+end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -379,4 +379,16 @@ end
     @test StructUtils.make(SomeStruct, Dict(:my_field => 45)).my_field == 45
 end
 
+if VERSION >= v"1.11"
+    using StaticArrays
+
+    @testset "StaticArrays" begin
+        @test StructUtils.make(SVector{3,Int}, [1, 2, 3]) == SVector{3,Int}((1, 2, 3))
+        @test StructUtils.make(SVector{2,Float64}, [1, 2]) == SVector{2,Float64}((1.0, 2.0))
+        @test StructUtils.make(SMatrix{2,2,Int}, [[1, 3], [2, 4]]) == SMatrix{2,2,Int}((1, 3, 2, 4))
+        @test StructUtils.make(MVector{3,Int}, [1, 2, 3]) == MVector{3,Int}((1, 2, 3))
+        @test StructUtils.make(Vector{SVector{2,Int}}, [[1, 2], [3, 4]]) == [SVector{2,Int}((1, 2)), SVector{2,Int}((3, 4))]
+    end
+end
+
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -379,16 +379,22 @@ end
     @test StructUtils.make(SomeStruct, Dict(:my_field => 45)).my_field == 45
 end
 
-if VERSION >= v"1.11"
-    using StaticArrays
+using StaticArrays
 
-    @testset "StaticArrays" begin
-        @test StructUtils.make(SVector{3,Int}, [1, 2, 3]) == SVector{3,Int}((1, 2, 3))
-        @test StructUtils.make(SVector{2,Float64}, [1, 2]) == SVector{2,Float64}((1.0, 2.0))
-        @test StructUtils.make(SMatrix{2,2,Int}, [[1, 3], [2, 4]]) == SMatrix{2,2,Int}((1, 3, 2, 4))
-        @test StructUtils.make(MVector{3,Int}, [1, 2, 3]) == MVector{3,Int}((1, 2, 3))
-        @test StructUtils.make(Vector{SVector{2,Int}}, [[1, 2], [3, 4]]) == [SVector{2,Int}((1, 2)), SVector{2,Int}((3, 4))]
-    end
+@testset "fixedsizearray trait" begin
+    @test StructUtils.fixedsizearray(Matrix{Int}) == true
+    @test StructUtils.fixedsizearray(Array{Float64, 3}) == true
+    @test StructUtils.fixedsizearray(Vector{Int}) == false
+    @test StructUtils.fixedsizearray(Set{Int}) == false
+    @test StructUtils.fixedsizearray(SVector{3, Int}) == true
+end
+
+@testset "StaticArrays" begin
+    @test StructUtils.make(SVector{3,Int}, [1, 2, 3]) == SVector{3,Int}((1, 2, 3))
+    @test StructUtils.make(SVector{2,Float64}, [1, 2]) == SVector{2,Float64}((1.0, 2.0))
+    @test StructUtils.make(SMatrix{2,2,Int}, [[1, 3], [2, 4]]) == SMatrix{2,2,Int}((1, 3, 2, 4))
+    @test StructUtils.make(MVector{3,Int}, [1, 2, 3]) == MVector{3,Int}((1, 2, 3))
+    @test StructUtils.make(Vector{SVector{2,Int}}, [[1, 2], [3, 4]]) == [SVector{2,Int}((1, 2)), SVector{2,Int}((3, 4))]
 end
 
 end


### PR DESCRIPTION
## Summary

- Adds a `fixedsizearray` trait to generalize the pre-allocate + `setindex!` array construction path (currently only used for `ndims > 1` arrays) to any fixed-size array type
- Adds a `StaticArraysCore` package extension that enables `StructUtils.make` for `SVector`, `SMatrix`, `MVector`, and other `StaticArray` types
- Uses `Memory{T}` as the flat backing buffer on Julia 1.11+, with the existing growable path as fallback

## Motivation

`StructUtils.makearray` assumes all 1D arrays are growable (`push!` into `T(undef, 0)`). This fails for `StaticArrays` which are fixed-size and immutable. The `ndims > 1` path already uses a pre-allocate + `setindex!` approach — this PR generalizes that pattern.

Closes JuliaIO/JSON.jl#429

## New public API

| Function | Purpose |
|---|---|
| `fixedsizearray(::Type{T})` | Trait: should T use the pre-allocate+fill path? |
| `discover_dims(style, ::Type{T}, source)` | Type-based dimension discovery (avoids scanning source) |
| `arrayfromdata(::Type{T}, mem, dims)` | Convert filled `Memory` buffer to target type T |
| `FixedArrayClosure` | `setindex!`-based 1D fill closure (vs `push!`-based `ArrayClosure`) |

## How it works

For `fixedsizearray` types on Julia 1.11+:
1. `discover_dims` gets dimensions (from type params for StaticArrays, source scan for regular Matrix)
2. `Memory{eltype(T)}(undef, prod(dims))` allocates a flat buffer
3. 1D: `FixedArrayClosure` fills via linear `setindex!`; nD: `MultiDimClosure` fills via reshaped view
4. `arrayfromdata` converts the filled Memory to the target type

The StaticArraysCore extension (3 methods):
- `fixedsizearray(::Type{<:StaticArray}) = true`
- `discover_dims` reads dimensions from type parameters (no source scanning)
- `arrayfromdata` converts via `T(Tuple(mem))` (StaticArrays' native representation)

## Test plan

- [x] All existing StructUtils tests pass (`Pkg.test()`)
- [x] New StaticArrays testset: SVector, SMatrix, MVector, nested Vector{SVector}
- [x] JSON.jl end-to-end: `JSON.parse("[1,2,3]", SVector{3,Int})` works
- [x] JSON.jl full test suite (917 tests) passes with dev StructUtils
- [ ] CI (Julia 1.9 fallback path, Julia 1.11+ Memory path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)