### PR TITLE
Add FieldError with field name context to parsing errors

### DIFF
--- a/src/StructUtils.jl
+++ b/src/StructUtils.jl
@@ -1020,7 +1020,7 @@ function makestruct(style, ::Type{T}, source) where {T}
                 try
                     fielddefault(style, T, fsyms[i])::fieldtype(T, i)
                 catch e
-                    throw(FieldError(T, fsyms[i], fieldtype(T, i), ArgumentError("missing required field")))
+                    throw(FieldError(T, fsyms[i], fieldtype(T, i), ArgumentError("required field is missing from input")))
                 end
             end
         end

--- a/src/StructUtils.jl
+++ b/src/StructUtils.jl
@@ -2,7 +2,25 @@ module StructUtils
 
 using Dates, UUIDs
 
-export @noarg, @defaults, @tags, @kwarg, @nonstruct, Selectors
+export @noarg, @defaults, @tags, @kwarg, @nonstruct, Selectors, FieldError
+
+"""
+    StructUtils.FieldError
+
+Error thrown when a field fails to parse during struct construction.
+Contains the struct type, field name, expected type, and the underlying error.
+"""
+struct FieldError <: Exception
+    struct_type::Type
+    field_name::Symbol
+    field_type::Type
+    error::Exception
+end
+
+function Base.showerror(io::IO, e::FieldError)
+    print(io, "FieldError: failed to parse field `$(e.field_name)::$(e.field_type)` of `$(e.struct_type)`: ")
+    showerror(io, e.error)
+end
 
 """
     StructUtils.StructStyle
@@ -925,6 +943,20 @@ end
 
 setval!(vals::T, x, i) where {T} = _setfield!(vals, i, x)
 
+function _make_field(f, ::Type{T}, i, v) where {T}
+    fn = f.fsyms[i]
+    FT = fieldtype(T, i)
+    ftags = fieldtags(f.style, T, fn)
+    try
+        val, st = make(f.style, FT, v, ftags)
+        setval!(f.vals, val, i)
+        return EarlyReturn(st)
+    catch e
+        e isa FieldError && rethrow()
+        throw(FieldError(T, fn, FT, e))
+    end
+end
+
 function findfield(::Type{T}, k, v, f) where {T}
     st = _foreach(T) do i
         if typeof(k) == Symbol
@@ -932,16 +964,11 @@ function findfield(::Type{T}, k, v, f) where {T}
             ftags = fieldtags(f.style, T, fn)
             field = get(ftags, :name, fn)
             if keyeq(k, field) || keyeq(k, fn)
-                symval, symst = make(f.style, fieldtype(T, i), v, ftags)
-                setval!(f.vals, symval, i)
-                return EarlyReturn(symst)
+                return _make_field(f, T, i, v)
             end
         elseif typeof(k) == Int
             if k == i
-                ftags = fieldtags(f.style, T, f.fsyms[i])
-                intval, intst = make(f.style, fieldtype(T, i), v, ftags)
-                setval!(f.vals, intval, i)
-                return EarlyReturn(intst)
+                return _make_field(f, T, i, v)
             end
         else
             fn = f.fsyms[i]
@@ -949,9 +976,7 @@ function findfield(::Type{T}, k, v, f) where {T}
             ftags = fieldtags(f.style, T, fn)
             field = get(ftags, :name, fstr)
             if keyeq(k, field)
-                strval, strst = make(f.style, fieldtype(T, i), v, ftags)
-                setval!(f.vals, strval, i)
-                return EarlyReturn(strst)
+                return _make_field(f, T, i, v)
             end
         end
     end
@@ -989,6 +1014,16 @@ function makestruct(style, ::Type{T}, source) where {T}
     if T <: NamedTuple
         return T(_tuple(T, vals, style)), st
     else
+        # Check for missing required fields before construction
+        for i in 1:fieldcount(T)
+            if !isassigned(vals, i)
+                try
+                    fielddefault(style, T, fsyms[i])::fieldtype(T, i)
+                catch e
+                    throw(FieldError(T, fsyms[i], fieldtype(T, i), ArgumentError("missing required field")))
+                end
+            end
+        end
         return _construct(T, vals, style, fsyms), st
     end
 end

--- a/src/StructUtils.jl
+++ b/src/StructUtils.jl
@@ -18,7 +18,7 @@ struct FieldError <: Exception
 end
 
 function Base.showerror(io::IO, e::FieldError)
-    print(io, "FieldError: failed to parse field `$(e.field_name)::$(e.field_type)` of `$(e.struct_type)`: ")
+    print(io, "FieldError: $(e.struct_type).$(e.field_name)::$(e.field_type): ")
     showerror(io, e.error)
 end
 


### PR DESCRIPTION
## Summary

When struct parsing fails, errors like `MethodError` or `TypeError` are thrown without any indication of **which field** caused the failure. This makes debugging JSON parsing issues unnecessarily difficult, especially with larger structs.

This PR adds a `FieldError` exception type that wraps the original error with field context.

## Before

```
# Wrong type
MethodError: Cannot `convert` an object of type Int64 to an object of type String

# Missing required field
TypeError(:typeassert, "", Int64, nothing)

# null for non-nullable
MethodError: Cannot `convert` an object of type Nothing to an object of type String
```

No indication of which field failed or which struct was being parsed.

## After

```
# Wrong type
FieldError: Bar.path::String: MethodError: Cannot `convert`...

# Missing required field
FieldError: Bar.count::Int64: ArgumentError: required field is missing from input

# null for non-nullable
FieldError: Bar.path::String: MethodError: Cannot `convert`...

# Nested struct failure
FieldError: Outer.inner::Inner: ArgumentError: applyeach not applicable...
```

## Implementation

- **`FieldError <: Exception`** — exported, contains `struct_type`, `field_name`, `field_type`, and `error` fields for programmatic access
- **`_make_field` helper** — wraps the `make()` + `setval!()` calls in `findfield()` with a try-catch that adds field context
- **Pre-construction check in `makestruct`** — detects missing required fields before `_construct` is called, giving a clear error instead of a cryptic `TypeError`
- Already-wrapped `FieldError`s from nested structs are rethrown as-is (no double-wrapping)

## Test plan

- [x] All 165 existing tests pass
- [x] Tested with JSON.jl v1.0 against all failure modes: wrong type, missing field, null→non-nullable, empty object, nested struct failure, array of structs
- [x] Valid parsing still works (extra fields ignored, defaults applied)