### PR TITLE
Disambiguate Union types with mixed arraylike/scalar members

### DIFF
--- a/src/StructUtils.jl
+++ b/src/StructUtils.jl
@@ -762,6 +762,34 @@ function make(style::StructStyle, T::Type, source, tags)
                 return make(style, Base.nonnothingtype(T), source, tags)
             end
         end
+        if T isa Union
+            types = Base.uniontypes(T)
+            arr_type = nothing
+            scalar_type = nothing
+            ambiguous = false
+            for t in types
+                if arraylike(style, t)
+                    if arr_type !== nothing
+                        ambiguous = true
+                        break
+                    end
+                    arr_type = t
+                else
+                    if scalar_type !== nothing
+                        ambiguous = true
+                        break
+                    end
+                    scalar_type = t
+                end
+            end
+            if !ambiguous && arr_type !== nothing && scalar_type !== nothing
+                if arraylike(style, source)
+                    return make(style, arr_type, source, tags)
+                else
+                    return make(style, scalar_type, source, tags)
+                end
+            end
+        end
     end
     if T <: Tuple || dictlike(style, T) || arraylike(style, T) || noarg(style, T) || structlike(style, T)
         return make(style, T, source)
@@ -784,6 +812,36 @@ function make(style::StructStyle, T::Type, source)
                 return make(style, Nothing, source)
             else
                 return make(style, Base.nonnothingtype(T), source)
+            end
+        end
+        # Union with a mix of arraylike and non-arraylike types:
+        # disambiguate based on whether the source is arraylike
+        if T isa Union
+            types = Base.uniontypes(T)
+            arr_type = nothing
+            scalar_type = nothing
+            ambiguous = false
+            for t in types
+                if arraylike(style, t)
+                    if arr_type !== nothing
+                        ambiguous = true
+                        break
+                    end
+                    arr_type = t
+                else
+                    if scalar_type !== nothing
+                        ambiguous = true
+                        break
+                    end
+                    scalar_type = t
+                end
+            end
+            if !ambiguous && arr_type !== nothing && scalar_type !== nothing
+                if arraylike(style, source)
+                    return make(style, arr_type, source)
+                else
+                    return make(style, scalar_type, source)
+                end
             end
         end
     end

--- a/src/StructUtils.jl
+++ b/src/StructUtils.jl
@@ -762,6 +762,9 @@ function make(style::StructStyle, T::Type, source, tags)
                 return make(style, Base.nonnothingtype(T), source, tags)
             end
         end
+        # for Union types like Union{T, Vector{T}} (after Nothing/Missing have been peeled),
+        # we can disambiguate by checking if source is arraylike;
+        # only applies when there's exactly one arraylike and one non-arraylike member
         if T isa Union
             types = Base.uniontypes(T)
             arr_type = nothing
@@ -769,6 +772,7 @@ function make(style::StructStyle, T::Type, source, tags)
             ambiguous = false
             for t in types
                 if arraylike(style, t)
+                    # more than one arraylike type means we can't disambiguate
                     if arr_type !== nothing
                         ambiguous = true
                         break
@@ -814,8 +818,9 @@ function make(style::StructStyle, T::Type, source)
                 return make(style, Base.nonnothingtype(T), source)
             end
         end
-        # Union with a mix of arraylike and non-arraylike types:
-        # disambiguate based on whether the source is arraylike
+        # for Union types like Union{T, Vector{T}} (after Nothing/Missing have been peeled),
+        # we can disambiguate by checking if source is arraylike;
+        # only applies when there's exactly one arraylike and one non-arraylike member
         if T isa Union
             types = Base.uniontypes(T)
             arr_type = nothing
@@ -823,6 +828,7 @@ function make(style::StructStyle, T::Type, source)
             ambiguous = false
             for t in types
                 if arraylike(style, t)
+                    # more than one arraylike type means we can't disambiguate
                     if arr_type !== nothing
                         ambiguous = true
                         break

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -326,6 +326,80 @@ end
     @test StructUtils.make(Dict{Symbol, Int}, (;)) == Dict{Symbol, Int}()
 end
 
+@testset "Union{scalar, array} disambiguation" begin
+    # basic: scalar source → scalar type, array source → array type
+    @test StructUtils.make(ScalarOrVec, (val=3.14,)).val === 3.14
+    @test StructUtils.make(ScalarOrVec, (val=[1.0, 2.0],)).val == [1.0, 2.0]
+    @test StructUtils.make(ScalarOrVec, (val=[1.0, 2.0],)).val isa Vector{Float64}
+
+    # Any-typed sources (the case that actually fails without disambiguation)
+    @test StructUtils.make(ScalarOrVec, Dict{String,Any}("val" => 3.14)).val === 3.14
+    x = StructUtils.make(ScalarOrVec, Dict{String,Any}("val" => Any[1.0, 2.0]))
+    @test x.val isa Vector{Float64}
+    @test x.val == [1.0, 2.0]
+
+    # String variant
+    @test StructUtils.make(ScalarOrVecStr, (val="hello",)).val == "hello"
+    x = StructUtils.make(ScalarOrVecStr, Dict{String,Any}("val" => Any["a", "b"]))
+    @test x.val isa Vector{String}
+    @test x.val == ["a", "b"]
+
+    # Int variant
+    @test StructUtils.make(ScalarOrVecInt, (val=42,)).val === 42
+    x = StructUtils.make(ScalarOrVecInt, Dict{String,Any}("val" => Any[1, 2, 3]))
+    @test x.val isa Vector{Int}
+    @test x.val == [1, 2, 3]
+
+    # with Nothing — Nothing is peeled first, then array/scalar split
+    @test StructUtils.make(ScalarOrVecNothing, (val=nothing,)).val === nothing
+    @test StructUtils.make(ScalarOrVecNothing, (val=5,)).val === 5
+    x = StructUtils.make(ScalarOrVecNothing, Dict{String,Any}("val" => Any[1, 2]))
+    @test x.val isa Vector{Int}
+    @test x.val == [1, 2]
+
+    # with Missing — Missing is peeled first, then array/scalar split
+    @test StructUtils.make(ScalarOrVecMissing, (val=missing,)) == ScalarOrVecMissing(missing)
+    @test StructUtils.make(ScalarOrVecMissing, (val=1.5,)).val === 1.5
+    x = StructUtils.make(ScalarOrVecMissing, Dict{String,Any}("val" => Any[1.0, 2.0]))
+    @test x.val isa Vector{Float64}
+    @test x.val == [1.0, 2.0]
+
+    # empty array → array type
+    x = StructUtils.make(ScalarOrVec, (val=Float64[],))
+    @test x.val isa Vector{Float64}
+    @test isempty(x.val)
+
+    # nested struct with Union field
+    x = StructUtils.make(ScalarOrVecNested, Dict{String,Any}("id" => 1, "data" => Any[1.0, 2.0, 3.0]))
+    @test x.id == 1
+    @test x.data isa Vector{Float64}
+    @test x.data == [1.0, 2.0, 3.0]
+    x = StructUtils.make(ScalarOrVecNested, (id=1, data=3.14))
+    @test x.id == 1
+    @test x.data === 3.14
+
+    # the original issue: Tuple with complex nested Union types
+    x = StructUtils.make(FrankenTuple, (params=(nothing, [1.0, 2.0, 3.0], nothing),))
+    @test x.params[1] === nothing
+    @test x.params[2] isa Vector{Float64}
+    @test x.params[2] == [1.0, 2.0, 3.0]
+    @test x.params[3] === nothing
+    # same tuple, all scalars
+    x = StructUtils.make(FrankenTuple, (params=(1.0, 2.0, 3.0),))
+    @test x.params[1] === 1.0
+    @test x.params[2] === 2.0
+    @test x.params[3] === 3.0
+
+    # ambiguous: two arraylike types → should NOT be handled, falls through
+    @test_throws Exception StructUtils.make(@NamedTuple{val::Union{Vector{Int}, Set{Int}}}, Dict{String,Any}("val" => Any[1, 2]))
+
+    # Vector of structs with Union fields
+    x = StructUtils.make(Vector{ScalarOrVec}, [(val=1.0,), (val=[2.0, 3.0],)])
+    @test x[1].val === 1.0
+    @test x[2].val isa Vector{Float64}
+    @test x[2].val == [2.0, 3.0]
+end
+
 @testset "BigInt/BigFloat structlike" begin
     # BigInt and BigFloat are mutable structs in Julia, but should be treated
     # as non-struct types for serialization purposes (JuliaIO/JSON.jl#424)

--- a/test/struct.jl
+++ b/test/struct.jl
@@ -223,3 +223,34 @@ struct Q
     id::Int
     value::MIME
 end
+
+# Union{scalar, array} disambiguation test types
+struct ScalarOrVec
+    val::Union{Float64, Vector{Float64}}
+end
+
+struct ScalarOrVecStr
+    val::Union{String, Vector{String}}
+end
+
+struct ScalarOrVecInt
+    val::Union{Int, Vector{Int}}
+end
+
+struct ScalarOrVecNothing
+    val::Union{Int, Vector{Int}, Nothing}
+end
+
+struct ScalarOrVecMissing
+    val::Union{Float64, Vector{Float64}, Missing}
+end
+Base.:(==)(a::ScalarOrVecMissing, b::ScalarOrVecMissing) = isequal(a.val, b.val)
+
+struct ScalarOrVecNested
+    id::Int
+    data::Union{Float64, Vector{Float64}}
+end
+
+struct FrankenTuple
+    params::Tuple{Union{Float64, Nothing}, Union{Vector{Float64}, Float64}, Union{Vector{Float64}, Float64, Nothing}}
+end


### PR DESCRIPTION
## Summary
- When `make` encounters a Union type (after Nothing/Missing peeling) that has exactly one `arraylike` member and one non-`arraylike` member, disambiguate by checking `arraylike(style, source)`
- If the source is arraylike → narrow to the array member type; otherwise → narrow to the scalar member type
- Ambiguous cases (2+ array types or 2+ scalar types) fall through to existing behavior (e.g. `@choosetype`)
- Applied to both `make(style, T, source, tags)` and `make(style, T, source)` variants

## Context
Fixes https://github.com/JuliaIO/JSON.jl/issues/436

Parsing JSON into a struct with `Union{Float64, Vector{Float64}}` fields (or similar) fails because `make` has no logic for non-Nothing/Missing Unions — it falls through to `lift` → `convert`, which can't handle `convert(Union{Float64, Vector{Float64}}, Vector{Any}(...))`.

The fix is deterministic (no try/catch) and conservative (only activates for unambiguous 1-array-1-scalar splits).

## Test plan
- [ ] Existing StructUtils tests pass
- [ ] JSON.jl tests added in companion PR: tests for `Union{T, Vector{T}}`, `Union{T, Vector{T}, Nothing}`, `Union{T, Vector{T}, Missing}`, ambiguous unions, empty arrays, nested structs, and the original issue's franken-tuple


🤖 Generated with [Claude Code](https://claude.com/claude-code)