### PR TITLE
Add 3-arg fielddefaults(style, T, vals) to support dependent defaults…

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -24,6 +24,7 @@ julia = "1.9"
 
 [extras]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+JuliaC = "acedd4c2-ced6-4a15-accc-2607eb759ba2"
 Measurements = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
@@ -32,4 +33,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [targets]
-test = ["Dates", "Measurements", "StaticArrays", "StaticArraysCore", "Tables", "Test", "UUIDs"]
+test = ["Dates", "JuliaC", "Measurements", "StaticArrays", "StaticArraysCore", "Tables", "Test", "UUIDs"]

--- a/Project.toml
+++ b/Project.toml
@@ -24,7 +24,6 @@ julia = "1.9"
 
 [extras]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
-JuliaC = "acedd4c2-ced6-4a15-accc-2607eb759ba2"
 Measurements = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
@@ -33,4 +32,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [targets]
-test = ["Dates", "JuliaC", "Measurements", "StaticArrays", "StaticArraysCore", "Tables", "Test", "UUIDs"]
+test = ["Dates", "Measurements", "StaticArrays", "StaticArraysCore", "Tables", "Test", "UUIDs"]

--- a/src/StructUtils.jl
+++ b/src/StructUtils.jl
@@ -147,6 +147,7 @@ using the StructUtils.jl macros: `@tags`, `@noarg`, `@defaults`, or `@kwarg`.
 function fielddefaults end
 
 fielddefaults(::StructStyle, T::Type)::NamedTuple{(),Tuple{}} = (;)
+fielddefaults(st::StructStyle, T::Type, vals) = fielddefaults(st, T)
 fielddefault(st::StructStyle, T::Type, key) = get(fielddefaults(st, T), key, nothing)
 
 "See [`fielddefaults`](@ref)."
@@ -1118,14 +1119,20 @@ function makenoarg(style, y::T, source) where {T}
 end
 
 macro _v(i)
-    esc(:(isassigned(vals, $i) ? @inbounds(vals[$i])::fieldtype(T, $i) : fielddefault(style, T, @inbounds(fsyms[$i]))::fieldtype(T, $i)))
+    esc(:(isassigned(vals, $i) ? @inbounds(vals[$i])::fieldtype(T, $i) : get(defs, @inbounds(fsyms[$i]), nothing)::fieldtype(T, $i)))
 end
 
 @generated function _construct(::Type{T}, vals, style, fsyms) where {T}
     n = fieldcount(T)
     ex = Expr(:block)
     push!(ex.args, :(Base.@_inline_meta))
-    push!(ex.args, Expr(:call, Any[:T, [:(@_v($i)) for i = 1:n]...]...))
+    # fast path: all fields assigned, skip fielddefaults entirely
+    all_assigned = Expr(:&&, [:(isassigned(vals, $i)) for i = 1:n]...)
+    fast = Expr(:call, Any[:T, [:(@inbounds(vals[$i])::fieldtype(T, $i)) for i = 1:n]...]...)
+    slow = Expr(:block,
+        :(defs = fielddefaults(style, T, vals)),
+        Expr(:call, Any[:T, [:(@_v($i)) for i = 1:n]...]...))
+    push!(ex.args, Expr(:if, all_assigned, fast, slow))
     return ex
 end
 

--- a/src/StructUtils.jl
+++ b/src/StructUtils.jl
@@ -1170,7 +1170,8 @@ function make!(style::StructStyle, ::Type{T}, source) where {T}
     return x
 end
 
-@doc (@doc make) make!
+"See [`make`](@ref)."
+make!
 
 """
     StructUtils.reset!(x::T)

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -256,6 +256,21 @@ function generate_field_defaults_and_tags!(ret, T, fields)
         defs_nt = Expr(:tuple, Expr(:parameters, [:(($(f.name)=$(f.name))) for f in fields_with_defaults]...))
         push!(body.args, Expr(:return, defs_nt))
         push!(ret.args, Expr(:(=), Expr(:call, GlobalRef(StructUtils, :fielddefaults), Expr(:(::), GlobalRef(StructUtils, :StructStyle)), Expr(:(::), Expr(:curly, :Type, Expr(:(<:), T)))), body))
+        # Generate 3-arg fielddefaults override that uses parsed values from `vals`.
+        # Evaluates ALL fields in order (not just those with defaults), using
+        # the parsed value from vals when assigned, else the default expression.
+        # This lets dependent defaults like `b = string(a)` use the parsed value of `a`.
+        body2 = Expr(:block)
+        for (i, f) in enumerate(fields)
+            if f.default !== none
+                push!(body2.args, Expr(:(=), f.name, :(isassigned(vals, $i) ? vals[$i] : $(f.default))))
+            else
+                push!(body2.args, Expr(:(=), f.name, :(isassigned(vals, $i) ? vals[$i] : nothing)))
+            end
+        end
+        defs_nt2 = Expr(:tuple, Expr(:parameters, [:(($(f.name)=$(f.name))) for f in fields_with_defaults]...))
+        push!(body2.args, Expr(:return, defs_nt2))
+        push!(ret.args, Expr(:(=), Expr(:call, GlobalRef(StructUtils, :fielddefaults), Expr(:(::), GlobalRef(StructUtils, :StructStyle)), Expr(:(::), Expr(:curly, :Type, Expr(:(<:), T))), :vals), body2))
     end
     # generate fieldtags override if applicable
     if any(f.tags !== none for f in fields)

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -262,10 +262,13 @@ function generate_field_defaults_and_tags!(ret, T, fields)
         # This lets dependent defaults like `b = string(a)` use the parsed value of `a`.
         body2 = Expr(:block)
         for (i, f) in enumerate(fields)
+            # Add type assertion to vals[$i] when field type is known,
+            # so computed default expressions get typed inputs (trim-safe).
+            val_expr = f.type === none ? :(vals[$i]) : :(vals[$i]::$(f.type))
             if f.default !== none
-                push!(body2.args, Expr(:(=), f.name, :(isassigned(vals, $i) ? vals[$i] : $(f.default))))
+                push!(body2.args, Expr(:(=), f.name, :(isassigned(vals, $i) ? $val_expr : $(f.default))))
             else
-                push!(body2.args, Expr(:(=), f.name, :(isassigned(vals, $i) ? vals[$i] : nothing)))
+                push!(body2.args, Expr(:(=), f.name, :(isassigned(vals, $i) ? $val_expr : nothing)))
             end
         end
         defs_nt2 = Expr(:tuple, Expr(:parameters, [:(($(f.name)=$(f.name))) for f in fields_with_defaults]...))

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -364,4 +364,76 @@ end
         @test x.b == 1
     end
 
+    @testset "computedefaults with parsed values" begin
+        # Dependent default where first field has no default (the JSON.jl #430 case)
+        @defaults struct ComputedA
+            a::Int
+            b::String = string(a)
+        end
+        # Direct construction still works
+        @test ComputedA(42) == ComputedA(42, "42")
+        # Deserialization: b computed from parsed a
+        r = StructUtils.make(ComputedA, Dict(:a => 42))
+        @test r.a == 42
+        @test r.b == "42"
+        # Both fields provided: b uses provided value, not computed
+        r2 = StructUtils.make(ComputedA, Dict(:a => 42, :b => "hello"))
+        @test r2.a == 42
+        @test r2.b == "hello"
+
+        # Dependent default where first field also has a default
+        @defaults struct ComputedB
+            a::Int = 0
+            b::String = string(a)
+        end
+        # No fields provided: b computed from a's default
+        r3 = StructUtils.make(ComputedB, Dict{Symbol,Any}())
+        @test r3.a == 0
+        @test r3.b == "0"
+        # Only a provided: b computed from parsed a
+        r4 = StructUtils.make(ComputedB, Dict(:a => 7))
+        @test r4.a == 7
+        @test r4.b == "7"
+
+        # @kwarg with dependent defaults and deserialization
+        @kwarg struct ComputedC
+            a::Int = 1
+            b::Int = a + 10
+            c::Int = a + b
+        end
+        # All defaults
+        r5 = StructUtils.make(ComputedC, Dict{Symbol,Any}())
+        @test r5.a == 1
+        @test r5.b == 11
+        @test r5.c == 12
+        # Override a, b and c recompute
+        r6 = StructUtils.make(ComputedC, Dict(:a => 5))
+        @test r6.a == 5
+        @test r6.b == 15
+        @test r6.c == 20
+        # Override a and b, c recomputes from parsed values
+        r7 = StructUtils.make(ComputedC, Dict(:a => 5, :b => 100))
+        @test r7.a == 5
+        @test r7.b == 100
+        @test r7.c == 105
+
+        # Non-macro struct: computedefaults falls back to fielddefaults
+        struct ComputedPlain
+            x::Int
+            y::Int
+        end
+        r8 = StructUtils.make(ComputedPlain, Dict(:x => 1, :y => 2))
+        @test r8.x == 1
+        @test r8.y == 2
+
+        # Expression-based default (not just field reference)
+        @defaults struct ComputedD
+            x::Int
+            y::Int
+            label::String = "$(x)-$(y)"
+        end
+        r9 = StructUtils.make(ComputedD, Dict(:x => 3, :y => 4))
+        @test r9.label == "3-4"
+    end
+
 end # @testset "macros"

--- a/test/make_trim_safe.jl
+++ b/test/make_trim_safe.jl
@@ -1,0 +1,91 @@
+using StructUtils
+
+# Plain struct (no defaults)
+struct TrimA
+    a::Int
+    b::Int
+    c::Int
+    d::Int
+end
+
+# Struct with simple defaults
+@defaults struct TrimB
+    a::Int
+    b::Int
+    c::Int = 0
+    d::Int = 0
+end
+
+# Struct with computed/dependent defaults
+@defaults struct TrimC
+    a::Int
+    b::String = string(a)
+end
+
+# @kwarg struct with chained defaults
+@kwarg struct TrimD
+    a::Int = 1
+    b::Int = a + 10
+    c::Int = a + b
+end
+
+# @noarg mutable struct
+@noarg mutable struct TrimE
+    a::Int = 0
+    b::Int = 0
+end
+
+function run_make_trim_sample()::Nothing
+    # 1. Plain struct from NamedTuple
+    a = StructUtils.make(TrimA, (a=1, b=2, c=3, d=4))
+    a.a == 1 || error("TrimA.a")
+    a.d == 4 || error("TrimA.d")
+
+    # 2. Plain struct from Dict{Symbol,Int} (homogeneous value type)
+    a2 = StructUtils.make(TrimA, Dict{Symbol,Int}(:a => 1, :b => 2, :c => 3, :d => 4))
+    a2.a == 1 || error("TrimA Dict")
+
+    # 3. Struct with defaults — all provided
+    b1 = StructUtils.make(TrimB, (a=1, b=2, c=3, d=4))
+    b1.c == 3 || error("TrimB all")
+
+    # 4. Struct with defaults — defaults used
+    b2 = StructUtils.make(TrimB, (a=1, b=2))
+    b2.c == 0 || error("TrimB defaults")
+
+    # 5. Computed defaults — default used
+    c1 = StructUtils.make(TrimC, (a=42,))
+    c1.b == "42" || error("TrimC computed")
+
+    # 6. Computed defaults — all provided
+    c2 = StructUtils.make(TrimC, (a=42, b="hello"))
+    c2.b == "hello" || error("TrimC provided")
+
+    # 7. Chained kwarg defaults
+    d1 = StructUtils.make(TrimD, (a=5,))
+    d1.b == 15 || error("TrimD.b")
+    d1.c == 20 || error("TrimD.c")
+
+    # 8. @noarg mutable struct
+    e = StructUtils.make(TrimE, (a=10, b=20))
+    e.a == 10 || error("TrimE.a")
+
+    # 9. NamedTuple target
+    nt = StructUtils.make(@NamedTuple{a::Int, b::Int}, (a=1, b=2))
+    nt.a == 1 || error("NamedTuple")
+
+    # 10. applyeach (serialization direction)
+    count = Ref(0)
+    StructUtils.applyeach(StructUtils.DefaultStyle(), (k, v) -> (count[] += 1; nothing), a)
+    count[] == 4 || error("applyeach")
+
+    return nothing
+end
+
+function @main(args::Vector{String})::Cint
+    _ = args
+    run_make_trim_sample()
+    return 0
+end
+
+Base.Experimental.entrypoint(main, (Vector{String},))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -488,3 +488,5 @@ end
 end
 
 end
+
+include("trim_compile_tests.jl")

--- a/test/trim_compile_tests.jl
+++ b/test/trim_compile_tests.jl
@@ -165,6 +165,9 @@ end
     elseif _TRIM_PRE_RELEASE
         println("[trim] skip prerelease Julia: trim verifier behavior is not stable yet")
         @test true
+    elseif Sys.iswindows()
+        println("[trim] skip Windows: JuliaC-compiled binaries hang on Windows CI")
+        @test true
     else
         project_path = _setup_trim_env()
         trim_workloads = [

--- a/test/trim_compile_tests.jl
+++ b/test/trim_compile_tests.jl
@@ -5,9 +5,45 @@ const _TRIM_SUPPORTED = VERSION >= v"1.12.0-rc1"
 const _TRIM_PRE_RELEASE = !isempty(VERSION.prerelease)
 const _JULIAC_ENTRYPOINT_EXPR = "using JuliaC; if isdefined(JuliaC, :main); JuliaC.main(ARGS); else JuliaC._main_cli(ARGS); end"
 
+# Pkg.test() sets JULIA_LOAD_PATH restrictively, which prevents subprocesses
+# from finding stdlib packages like Pkg.  Strip it so subprocesses get the
+# default load path.
+function _clean_cmd(cmd::Cmd)
+    return addenv(cmd, "JULIA_LOAD_PATH" => "@:@stdlib")
+end
+
+function _setup_trim_env()
+    # JuliaC requires Julia 1.12+ and can't be in [extras] without breaking
+    # Pkg.test() on older Julia versions.  Create a temp project that dev's
+    # StructUtils from the local checkout and adds JuliaC.
+    su_path = normpath(joinpath(@__DIR__, ".."))
+    env_path = mktempdir()
+    julia = joinpath(Sys.BINDIR, Base.julia_exename())
+    setup_script = joinpath(env_path, "setup.jl")
+    write(setup_script, """
+    import Pkg
+    Pkg.develop(path=$(repr(su_path)))
+    Pkg.add("JuliaC")
+    """)
+    println("[trim] setting up temp environment with JuliaC...")
+    flush(stdout)
+    exit_code, output, timed_out = _run_command_with_timeout(
+        _clean_cmd(`$julia --startup-file=no --history-file=no --project=$env_path $setup_script`);
+        timeout_s = 120.0, log_label = "setup"
+    )
+    rm(setup_script; force = true)
+    if exit_code != 0 || timed_out
+        println("[trim] setup FAILED (exit=$exit_code, timed_out=$timed_out)")
+        println(output)
+        error("failed to set up trim test environment")
+    end
+    println("[trim] temp environment ready")
+    return env_path
+end
+
 function _run_trim_compile(project_path::String, script_path::String, output_name::String; timeout_s::Float64 = 120.0)
     julia_exe = joinpath(Sys.BINDIR, Base.julia_exename())
-    cmd = `$julia_exe --startup-file=no --history-file=no --code-coverage=none --project=$project_path -e $(_JULIAC_ENTRYPOINT_EXPR) -- --output-exe $output_name --project=$project_path --experimental --trim=safe $script_path`
+    cmd = _clean_cmd(`$julia_exe --startup-file=no --history-file=no --code-coverage=none --project=$project_path -e $(_JULIAC_ENTRYPOINT_EXPR) -- --output-exe $output_name --project=$project_path --experimental --trim=safe $script_path`)
     return _run_command_with_timeout(cmd; timeout_s = timeout_s, log_label = "compile")
 end
 
@@ -62,6 +98,11 @@ function _parse_trim_verify_totals(output::String)
     return parse(Int, m.captures[1]), parse(Int, m.captures[2])
 end
 
+function _trim_executable_timeout_s()::Float64
+    default = Sys.iswindows() ? "120.0" : "30.0"
+    return parse(Float64, get(ENV, "STRUCTUTILS_TRIM_EXE_TIMEOUT_S", default))
+end
+
 function _run_trim_case(project_path::String, script_file::String, output_name::String)
     script_path = joinpath(@__DIR__, script_file)
     @test isfile(script_path)
@@ -93,7 +134,7 @@ function _run_trim_case(project_path::String, script_file::String, output_name::
             if trim_errors == 0
                 @test exit_code == 0
                 @test isfile(output_path)
-                run_timeout_s = parse(Float64, get(ENV, "STRUCTUTILS_TRIM_EXE_TIMEOUT_S", "30.0"))
+                run_timeout_s = _trim_executable_timeout_s()
                 run_cmd = `$(abspath(output_path))`
                 run_exit, run_output, run_timed_out = _run_command_with_timeout(run_cmd; timeout_s = run_timeout_s, log_label = "run")
                 if run_timed_out
@@ -124,7 +165,7 @@ end
         println("[trim] skip prerelease Julia: trim verifier behavior is not stable yet")
         @test true
     else
-        project_path = normpath(joinpath(@__DIR__, ".."))
+        project_path = _setup_trim_env()
         trim_workloads = [
             ("make_trim_safe.jl", "make_trim_safe"),
         ]

--- a/test/trim_compile_tests.jl
+++ b/test/trim_compile_tests.jl
@@ -6,10 +6,11 @@ const _TRIM_PRE_RELEASE = !isempty(VERSION.prerelease)
 const _JULIAC_ENTRYPOINT_EXPR = "using JuliaC; if isdefined(JuliaC, :main); JuliaC.main(ARGS); else JuliaC._main_cli(ARGS); end"
 
 # Pkg.test() sets JULIA_LOAD_PATH restrictively, which prevents subprocesses
-# from finding stdlib packages like Pkg.  Strip it so subprocesses get the
+# from finding stdlib packages like Pkg.  Remove it so subprocesses get the
 # default load path.
 function _clean_cmd(cmd::Cmd)
-    return addenv(cmd, "JULIA_LOAD_PATH" => "@:@stdlib")
+    env = Dict{String,String}(k => v for (k, v) in ENV if k != "JULIA_LOAD_PATH")
+    return setenv(cmd, env)
 end
 
 function _setup_trim_env()

--- a/test/trim_compile_tests.jl
+++ b/test/trim_compile_tests.jl
@@ -13,6 +13,11 @@ function _clean_cmd(cmd::Cmd)
     return setenv(cmd, env)
 end
 
+function _trim_use_bundle()::Bool
+    default = Sys.iswindows() ? "1" : "0"
+    return get(ENV, "STRUCTUTILS_TRIM_BUNDLE", default) == "1"
+end
+
 function _setup_trim_env()
     # JuliaC requires Julia 1.12+ and can't be in [extras] without breaking
     # Pkg.test() on older Julia versions.  Create a temp project that dev's
@@ -42,9 +47,13 @@ function _setup_trim_env()
     return env_path
 end
 
-function _run_trim_compile(project_path::String, script_path::String, output_name::String; timeout_s::Float64 = 120.0)
+function _run_trim_compile(project_path::String, script_path::String, output_name::String; timeout_s::Float64 = 120.0, bundle_dir::Union{Nothing, String} = nothing)
     julia_exe = joinpath(Sys.BINDIR, Base.julia_exename())
-    cmd = _clean_cmd(`$julia_exe --startup-file=no --history-file=no --code-coverage=none --project=$project_path -e $(_JULIAC_ENTRYPOINT_EXPR) -- --output-exe $output_name --project=$project_path --experimental --trim=safe $script_path`)
+    cmd = if bundle_dir === nothing
+        _clean_cmd(`$julia_exe --startup-file=no --history-file=no --code-coverage=none --project=$project_path -e $(_JULIAC_ENTRYPOINT_EXPR) -- --output-exe $output_name --project=$project_path --experimental --trim=safe $script_path`)
+    else
+        _clean_cmd(`$julia_exe --startup-file=no --history-file=no --code-coverage=none --project=$project_path -e $(_JULIAC_ENTRYPOINT_EXPR) -- --output-exe $output_name --bundle $bundle_dir --project=$project_path --experimental --trim=safe $script_path`)
+    end
     return _run_command_with_timeout(cmd; timeout_s = timeout_s, log_label = "compile")
 end
 
@@ -111,7 +120,8 @@ function _run_trim_case(project_path::String, script_file::String, output_name::
     start_t = time()
     mktempdir() do tmpdir
         cd(tmpdir) do
-            exit_code, output, timed_out = _run_trim_compile(project_path, script_path, output_name)
+            bundle_dir = _trim_use_bundle() ? joinpath(tmpdir, "bundle") : nothing
+            exit_code, output, timed_out = _run_trim_compile(project_path, script_path, output_name; bundle_dir = bundle_dir)
             if timed_out
                 println("[trim] compile TIMED OUT for $(script_file)")
                 println(output)
@@ -133,10 +143,11 @@ function _run_trim_case(project_path::String, script_file::String, output_name::
             @test trim_warnings >= 0
             output_path = Sys.iswindows() ? "$(output_name).exe" : output_name
             if trim_errors == 0
+                run_path = bundle_dir === nothing ? output_path : joinpath(bundle_dir, "bin", output_path)
                 @test exit_code == 0
-                @test isfile(output_path)
+                @test isfile(run_path)
                 run_timeout_s = _trim_executable_timeout_s()
-                run_cmd = `$(abspath(output_path))`
+                run_cmd = `$(abspath(run_path))`
                 run_exit, run_output, run_timed_out = _run_command_with_timeout(run_cmd; timeout_s = run_timeout_s, log_label = "run")
                 if run_timed_out
                     println("[trim] executable TIMED OUT for $(script_file)")
@@ -164,9 +175,6 @@ end
         @test true
     elseif _TRIM_PRE_RELEASE
         println("[trim] skip prerelease Julia: trim verifier behavior is not stable yet")
-        @test true
-    elseif Sys.iswindows()
-        println("[trim] skip Windows: JuliaC-compiled binaries hang on Windows CI")
         @test true
     else
         project_path = _setup_trim_env()

--- a/test/trim_compile_tests.jl
+++ b/test/trim_compile_tests.jl
@@ -1,0 +1,135 @@
+using Test
+
+const _TRIM_SAFE_ERROR_BUDGET = 0
+const _TRIM_SUPPORTED = VERSION >= v"1.12.0-rc1"
+const _TRIM_PRE_RELEASE = !isempty(VERSION.prerelease)
+const _JULIAC_ENTRYPOINT_EXPR = "using JuliaC; if isdefined(JuliaC, :main); JuliaC.main(ARGS); else JuliaC._main_cli(ARGS); end"
+
+function _run_trim_compile(project_path::String, script_path::String, output_name::String; timeout_s::Float64 = 120.0)
+    julia_exe = joinpath(Sys.BINDIR, Base.julia_exename())
+    cmd = `$julia_exe --startup-file=no --history-file=no --code-coverage=none --project=$project_path -e $(_JULIAC_ENTRYPOINT_EXPR) -- --output-exe $output_name --project=$project_path --experimental --trim=safe $script_path`
+    return _run_command_with_timeout(cmd; timeout_s = timeout_s, log_label = "compile")
+end
+
+function _run_command_with_timeout(cmd::Cmd; timeout_s::Float64, log_label::String)
+    output_path = tempname()
+    out = open(output_path, "w")
+    exit_code = -1
+    timed_out = false
+    try
+        proc = run(pipeline(ignorestatus(cmd), stdout = out, stderr = out); wait = false)
+        timed_out = _wait_process_with_timeout!(proc; timeout_s = timeout_s, log_label = log_label)
+        exit_code = something(proc.exitcode, -1)
+    finally
+        close(out)
+    end
+    output = try
+        read(output_path, String)
+    catch
+        ""
+    finally
+        rm(output_path; force = true)
+    end
+    return exit_code, output, timed_out
+end
+
+function _wait_process_with_timeout!(proc::Base.Process; timeout_s::Float64, log_label::String)
+    started_at = time()
+    next_log_at = started_at + 10.0
+    timed_out = false
+    while Base.process_running(proc)
+        now = time()
+        if now - started_at >= timeout_s
+            timed_out = true
+            try; kill(proc); catch; end
+            break
+        end
+        if now >= next_log_at
+            elapsed = round(now - started_at; digits = 1)
+            println("[trim] $(log_label) WAIT $(elapsed)s")
+            flush(stdout)
+            next_log_at = now + 10.0
+        end
+        sleep(0.1)
+    end
+    try; wait(proc); catch; end
+    return timed_out
+end
+
+function _parse_trim_verify_totals(output::String)
+    m = match(r"Trim verify finished with\s+(\d+)\s+errors,\s+(\d+)\s+warnings\.", output)
+    m === nothing && return nothing
+    return parse(Int, m.captures[1]), parse(Int, m.captures[2])
+end
+
+function _run_trim_case(project_path::String, script_file::String, output_name::String)
+    script_path = joinpath(@__DIR__, script_file)
+    @test isfile(script_path)
+    println("[trim] compile START $(script_file)")
+    start_t = time()
+    mktempdir() do tmpdir
+        cd(tmpdir) do
+            exit_code, output, timed_out = _run_trim_compile(project_path, script_path, output_name)
+            if timed_out
+                println("[trim] compile TIMED OUT for $(script_file)")
+                println(output)
+                @test false
+                return
+            end
+            totals = _parse_trim_verify_totals(output)
+            trim_errors, trim_warnings = if totals === nothing
+                exit_code == 0 ? (0, 0) : error("failed to parse trim verifier summary:\n$output")
+            else
+                totals
+            end
+            if get(ENV, "STRUCTUTILS_TRIM_PRINT_OUTPUT", "0") == "1" || trim_errors > 0
+                println("---- trim compile output ($(script_file)) ----")
+                println(output)
+                println("---- end output ----")
+            end
+            @test trim_errors <= _TRIM_SAFE_ERROR_BUDGET
+            @test trim_warnings >= 0
+            output_path = Sys.iswindows() ? "$(output_name).exe" : output_name
+            if trim_errors == 0
+                @test exit_code == 0
+                @test isfile(output_path)
+                run_timeout_s = parse(Float64, get(ENV, "STRUCTUTILS_TRIM_EXE_TIMEOUT_S", "30.0"))
+                run_cmd = `$(abspath(output_path))`
+                run_exit, run_output, run_timed_out = _run_command_with_timeout(run_cmd; timeout_s = run_timeout_s, log_label = "run")
+                if run_timed_out
+                    println("[trim] executable TIMED OUT for $(script_file)")
+                    println(run_output)
+                end
+                if run_exit != 0
+                    println("---- trim executable output ($(script_file)) ----")
+                    println(run_output)
+                    println("---- end output ----")
+                end
+                @test !run_timed_out
+                @test run_exit == 0
+            else
+                @test exit_code != 0
+            end
+        end
+    end
+    println("[trim] compile DONE $(script_file) ($(round(time() - start_t; digits = 2))s)")
+    return nothing
+end
+
+@testset "Trim compile" begin
+    if !_TRIM_SUPPORTED
+        println("[trim] skip Julia < 1.12: JuliaC trim compilation is unavailable")
+        @test true
+    elseif _TRIM_PRE_RELEASE
+        println("[trim] skip prerelease Julia: trim verifier behavior is not stable yet")
+        @test true
+    else
+        project_path = normpath(joinpath(@__DIR__, ".."))
+        trim_workloads = [
+            ("make_trim_safe.jl", "make_trim_safe"),
+        ]
+        for (script_file, output_name) in trim_workloads
+            _run_trim_case(project_path, script_file, output_name)
+        end
+    end
+end


### PR DESCRIPTION
… during deserialization

When a struct has computed/dependent field defaults (e.g., `b = string(a)`), the 2-arg `fielddefaults` evaluates them using only default values. During deserialization this fails because the referenced field's value comes from parsed data, not its default. The new 3-arg method resolves defaults with access to already-parsed field values, so dependent defaults use parsed values when available. Fixes JuliaIO/JSON.jl#430.