### PR TITLE
[codex] Fix make for abstract collection targets

### DIFF
--- a/src/StructUtils.jl
+++ b/src/StructUtils.jl
@@ -794,6 +794,8 @@ else
     const _delete = delete
 end
 
+# Abstract collection targets are not constructible, so when the incoming value
+# already satisfies the abstract type we must preserve it instead of rebuilding.
 @inline abstractcollectionpassthrough(style::StructStyle, ::Type{T}, source) where {T} =
     isabstracttype(T) && source isa T && (dictlike(style, T) || arraylike(style, T))
 

--- a/src/StructUtils.jl
+++ b/src/StructUtils.jl
@@ -794,6 +794,9 @@ else
     const _delete = delete
 end
 
+@inline abstractcollectionpassthrough(style::StructStyle, ::Type{T}, source) where {T} =
+    isabstracttype(T) && source isa T && (dictlike(style, T) || arraylike(style, T))
+
 function make(style::StructStyle, T::Type, source, tags)
     if haskey(tags, :choosetype)
         return make(style, tags.choosetype(source), source, _delete(tags, :choosetype))
@@ -853,6 +856,9 @@ function make(style::StructStyle, T::Type, source, tags)
 end
 
 function make(style::StructStyle, T::Type, source)
+    if abstractcollectionpassthrough(style, T, source)
+        return source, defaultstate(style)
+    end
     # start with some hard-coded Union cases
     if T !== Any
         if T >: Missing && T !== Missing
@@ -1165,6 +1171,9 @@ function make!(style::StructStyle, x::T, source) where {T}
 end
 
 function make!(style::StructStyle, ::Type{T}, source) where {T}
+    if abstractcollectionpassthrough(style, T, source)
+        return source
+    end
     x = initialize(style, T, source)
     make!(style, x, source)
     return x

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,6 +22,7 @@ t = (1, 2, 3, 4)
 
 println("Dict{Symbol, Int}")
 @test StructUtils.make(Dict{Symbol, Int}, d) == d
+@test StructUtils.make(Dict{Symbol, Int}, d) !== d
 @test StructUtils.make(Dict{Symbol, Int}, ds) == d
 @test StructUtils.make(Dict{Symbol, Int}, nt) == d
 @test StructUtils.make(Dict{Symbol, Int}, a) == d
@@ -107,8 +108,27 @@ println("Vector")
 @test StructUtils.make(typeof(v), a) == v
 @test StructUtils.make(typeof(v), vp) == v
 @test StructUtils.make(typeof(v), v) == v
+@test StructUtils.make(typeof(v), v) !== v
 @test StructUtils.make(typeof(v), t) == v
 # @test StructUtils.make(typeof(v), aa) == v # fails because of extra field
+
+println("Abstract collections")
+ad = Dict("a" => 1)
+av = [1, 2, 3]
+
+@test StructUtils.make(AbstractDict, ad) === ad
+@test StructUtils.make(AbstractArray, av) === av
+@test StructUtils.make(AbstractVector, av) === av
+@test StructUtils.make!(AbstractDict, ad) === ad
+@test StructUtils.make!(AbstractArray, av) === av
+@test StructUtils.make!(AbstractVector, av) === av
+
+x = StructUtils.make(AbstractDictHolder, Dict("d" => ad))
+@test x.d === ad
+x = StructUtils.make(AbstractArrayHolder, Dict("a" => av))
+@test x.a === av
+x = StructUtils.make(AbstractVectorHolder, Dict("v" => av))
+@test x.v === av
 
 println("Tuple")
 # @test StructUtils.make(typeof(t), d) == t # relies on order of Dict elements

--- a/test/struct.jl
+++ b/test/struct.jl
@@ -86,6 +86,18 @@ struct Wrapper
     x::NamedTuple{(:a, :b), Tuple{Int, String}}
 end
 
+struct AbstractDictHolder
+    d::AbstractDict
+end
+
+struct AbstractArrayHolder
+    a::AbstractArray
+end
+
+struct AbstractVectorHolder
+    v::AbstractVector
+end
+
 mutable struct UndefGuy
     id::Int
     name::String


### PR DESCRIPTION
## Summary
- fix `StructUtils.make` for abstract collection targets like `AbstractDict`, `AbstractArray`, and `AbstractVector` when the incoming value already satisfies the field type
- preserve existing rebuild semantics for concrete `Dict` and `Vector` targets instead of broadening pass-through behavior
- add regression tests for both the abstract-collection fix and the concrete-container non-aliasing behavior

## Root cause
`make` routed abstract collection targets into the normal dict/array construction path, where `initialize` attempted to construct the abstract type directly. That works for concrete collection types, but fails for abstract field annotations because abstract collection types are not instantiable.

## Testing
- `julia --project=. -q --startup-file=no -e 'using StructUtils, Test; struct Foo; d::AbstractDict; end; struct Bar; a::AbstractArray; end; struct Baz; v::AbstractVector; end; d = Dict("a" => 1); v = [1,2,3]; @test StructUtils.make(Foo, Dict("d" => d)).d === d; @test StructUtils.make(Bar, Dict("a" => v)).a === v; @test StructUtils.make(Baz, Dict("v" => v)).v === v; @test StructUtils.make(Dict{String,Int}, d) !== d; @test StructUtils.make(Vector{Int}, v) !== v; @test StructUtils.make(AbstractDict, d) === d; @test StructUtils.make(AbstractArray, v) === v; @test StructUtils.make(AbstractVector, v) === v; println("targeted checks passed")'`
- `julia --project=. --startup-file=no -q -e 'using Pkg; Pkg.test()'`
