### PR TITLE
[codex] Fix arraylike public fallback

### DIFF
--- a/src/StructUtils.jl
+++ b/src/StructUtils.jl
@@ -218,7 +218,8 @@ arraylike(::Type{<:AbstractSet}) = true
 arraylike(::Type{<:Tuple}) = true
 arraylike(::Type{<:Base.Generator}) = true
 arraylike(::Type{<:Core.SimpleVector}) = true
-arraylike(@nospecialize(T)) = false
+arraylike(@nospecialize(::Type)) = false
+arraylike(@nospecialize(x)) = arraylike(typeof(x))
 
 """
     StructUtils.fixedsizearray(::Type{T}) -> Bool

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -226,6 +226,13 @@ StructUtils.reset!(p)
 println("Q")
 @test StructUtils.make(Q, (id=0, value="application/json")) == Q(0, MIME("application/json"))
 
+@testset "arraylike public API" begin
+    @test StructUtils.arraylike([1]) == true
+    @test StructUtils.arraylike((1, 2)) == true
+    @test StructUtils.arraylike(Set([1])) == true
+    @test StructUtils.arraylike(1) == false
+end
+
 @testset "applyeach with Pair" begin
     # Basic functionality - collect key-value pairs
     collected = []


### PR DESCRIPTION
## Summary
- fix the public `StructUtils.arraylike(x)` fallback so value calls dispatch through `typeof(x)`
- preserve the existing type-based trait methods while correcting the generic value path
- add regression tests for arrays, tuples, sets, and a scalar false case

## Root cause
The generic `arraylike` fallback used a single catch-all method that returned `false`, which meant value calls like `StructUtils.arraylike([1])` never reached the type-based trait definitions even though `StructUtils.arraylike(typeof([1]))` worked.

## Testing
- `julia --project=. -q --startup-file=no -e 'using StructUtils, Test; @test StructUtils.arraylike([1]); @test StructUtils.arraylike((1,2)); @test StructUtils.arraylike(Set([1])); @test !StructUtils.arraylike(1); @test StructUtils.arraylike(typeof([1])); println("targeted checks passed")'`
- `julia --project=. --startup-file=no -q -e 'using Pkg; Pkg.test()'`
