### PR TITLE
feat(make): add unknownfield hook

### DIFF
--- a/src/StructUtils.jl
+++ b/src/StructUtils.jl
@@ -519,6 +519,10 @@ struct EarlyReturn{T}
     value::T
 end
 
+struct _MatchedState{T}
+    value::T
+end
+
 applyeach(f, x) = applyeach(DefaultStyle(), f, x)
 applyeach(f, st::StructStyle, x) = applyeach(st, f, x)
 
@@ -970,7 +974,7 @@ function (f::TupleClosure{T,A,S})(k, v) where {T,A,S}
             if k == i
                 intval, intst = make(f.style, fieldtype(T, i), v)
                 @inbounds f.vals[i] = intval
-                return EarlyReturn(Some(intst))
+                return EarlyReturn(_MatchedState(intst))
             end
         else
             j = unsafe_load(f.i)
@@ -978,11 +982,11 @@ function (f::TupleClosure{T,A,S})(k, v) where {T,A,S}
                 unsafe_store!(f.i, i + 1)
                 elseval, elsest = make(f.style, fieldtype(T, i), v)
                 @inbounds f.vals[i] = elseval
-                return EarlyReturn(Some(elsest))
+                return EarlyReturn(_MatchedState(elsest))
             end
         end
     end
-    return st isa Some ? something(st) : unknownfield(f.style, T, k, v)
+    return st isa _MatchedState ? st.value : unknownfield(f.style, T, k, v)
 end
 
 function maketuple(style, ::Type{T}, source) where {T}
@@ -1107,14 +1111,14 @@ function findfield(::Type{T}, k, v, f) where {T}
             if keyeq(k, field) || keyeq(k, fn)
                 symval, symst = make(f.style, fieldtype(T, i), v, ftags)
                 setval!(f.vals, symval, i)
-                return EarlyReturn(Some(symst))
+                return EarlyReturn(_MatchedState(symst))
             end
         elseif typeof(k) == Int
             if k == i
                 ftags = fieldtags(f.style, T, f.fsyms[i])
                 intval, intst = make(f.style, fieldtype(T, i), v, ftags)
                 setval!(f.vals, intval, i)
-                return EarlyReturn(Some(intst))
+                return EarlyReturn(_MatchedState(intst))
             end
         else
             fn = f.fsyms[i]
@@ -1124,11 +1128,11 @@ function findfield(::Type{T}, k, v, f) where {T}
             if keyeq(k, field)
                 strval, strst = make(f.style, fieldtype(T, i), v, ftags)
                 setval!(f.vals, strval, i)
-                return EarlyReturn(Some(strst))
+                return EarlyReturn(_MatchedState(strst))
             end
         end
     end
-    return st isa Some ? something(st) : unknownfield(f.style, T, k, v)
+    return st isa _MatchedState ? st.value : unknownfield(f.style, T, k, v)
 end
 
 (f::StructClosure{T,A,S,FS,FSS})(k, v) where {T,A,S,FS,FSS} = findfield(T, k, v, f)

--- a/src/StructUtils.jl
+++ b/src/StructUtils.jl
@@ -116,6 +116,22 @@ returns `nothing`.
 defaultstate(::StructStyle) = nothing
 
 """
+    StructUtils.unknownfield(::StructStyle, ::Type{T}, key, value)
+
+Called from [`StructUtils.make`](@ref) and [`StructUtils.make!`](@ref) when a
+source key or index does not match any field or positional slot in the target
+type `T`.
+
+The default implementation ignores the extra input by returning
+[`StructUtils.defaultstate`](@ref). Custom struct styles can overload this to
+throw, return [`StructUtils.EarlyReturn`](@ref), or otherwise customize the
+behavior for unknown fields.
+"""
+function unknownfield end
+
+unknownfield(st::StructStyle, ::Type{T}, key, value) where {T} = defaultstate(st)
+
+"""
     StructUtils.fieldtags(::StructStyle, ::Type{T}) -> NamedTuple
     StructUtils.fieldtags(::StructStyle, ::Type{T}, fieldname) -> NamedTuple
 
@@ -954,7 +970,7 @@ function (f::TupleClosure{T,A,S})(k, v) where {T,A,S}
             if k == i
                 intval, intst = make(f.style, fieldtype(T, i), v)
                 @inbounds f.vals[i] = intval
-                return EarlyReturn(intst)
+                return EarlyReturn(Some(intst))
             end
         else
             j = unsafe_load(f.i)
@@ -962,11 +978,11 @@ function (f::TupleClosure{T,A,S})(k, v) where {T,A,S}
                 unsafe_store!(f.i, i + 1)
                 elseval, elsest = make(f.style, fieldtype(T, i), v)
                 @inbounds f.vals[i] = elseval
-                return EarlyReturn(elsest)
+                return EarlyReturn(Some(elsest))
             end
         end
     end
-    return st === nothing ? defaultstate(f.style) : st
+    return st isa Some ? something(st) : unknownfield(f.style, T, k, v)
 end
 
 function maketuple(style, ::Type{T}, source) where {T}
@@ -1091,14 +1107,14 @@ function findfield(::Type{T}, k, v, f) where {T}
             if keyeq(k, field) || keyeq(k, fn)
                 symval, symst = make(f.style, fieldtype(T, i), v, ftags)
                 setval!(f.vals, symval, i)
-                return EarlyReturn(symst)
+                return EarlyReturn(Some(symst))
             end
         elseif typeof(k) == Int
             if k == i
                 ftags = fieldtags(f.style, T, f.fsyms[i])
                 intval, intst = make(f.style, fieldtype(T, i), v, ftags)
                 setval!(f.vals, intval, i)
-                return EarlyReturn(intst)
+                return EarlyReturn(Some(intst))
             end
         else
             fn = f.fsyms[i]
@@ -1108,11 +1124,11 @@ function findfield(::Type{T}, k, v, f) where {T}
             if keyeq(k, field)
                 strval, strst = make(f.style, fieldtype(T, i), v, ftags)
                 setval!(f.vals, strval, i)
-                return EarlyReturn(strst)
+                return EarlyReturn(Some(strst))
             end
         end
     end
-    return st === nothing ? defaultstate(f.style) : st
+    return st isa Some ? something(st) : unknownfield(f.style, T, k, v)
 end
 
 (f::StructClosure{T,A,S,FS,FSS})(k, v) where {T,A,S,FS,FSS} = findfield(T, k, v, f)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,14 @@
 using Test, Dates, UUIDs, StructUtils
 
 struct TestStyle <: StructUtils.StructStyle end
+struct StrictUnknownFieldStyle <: StructUtils.StructStyle end
+struct UnknownFieldTestError <: Exception
+    target::Any
+    key::Any
+end
+
+StructUtils.unknownfield(::StrictUnknownFieldStyle, ::Type{T}, key, value) where {T} =
+    throw(UnknownFieldTestError(T, key))
 
 include(joinpath(dirname(pathof(StructUtils)), "../test/macros.jl"))
 include(joinpath(dirname(pathof(StructUtils)), "../test/struct.jl"))
@@ -139,6 +147,18 @@ println("Tuple")
 @test StructUtils.make(typeof(t), v) == t
 @test StructUtils.make(typeof(t), t) == t
 @test StructUtils.make(typeof(t), aa) == t
+
+@testset "unknownfield hook" begin
+    @test StructUtils.make(A, nt, StrictUnknownFieldStyle()) == a
+    @test_throws UnknownFieldTestError StructUtils.make(A, (a=1, b=2, c=3, d=4, e=5), StrictUnknownFieldStyle())
+    @test_throws UnknownFieldTestError StructUtils.make(typeof(nt), aa, StrictUnknownFieldStyle())
+    @test_throws UnknownFieldTestError StructUtils.make(typeof(t), [1, 2, 3, 4, 5], StrictUnknownFieldStyle())
+
+    pmut2 = P()
+    StructUtils.make!(pmut2, (id=0, name="Jane"); style=StrictUnknownFieldStyle())
+    @test pmut2.id == 0 && pmut2.name == "Jane"
+    @test_throws UnknownFieldTestError StructUtils.make!(pmut2, (id=0, name="Joan", rate=3.14); style=StrictUnknownFieldStyle())
+end
 
 println("C")
 @test StructUtils.make(C, ()) == C()


### PR DESCRIPTION
## Summary
- add a new StructUtils.unknownfield style hook for unmatched keys and indexes during make/make!
- route the tuple and struct construction paths through the hook while preserving the default ignore behavior
- add regression tests showing custom styles can turn extra inputs into errors

## Testing
- `julia --project -e 'using Pkg; Pkg.test()'`
