### PR TITLE
fix example with macros

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -447,7 +447,7 @@ StructUtils.@choosetype AbstractMonster x ->
     Dracula : Werewolf
 
 # Custom numeric type with special parsing
-struct Percent <: Number
+@nonstruct struct Percent <: Number
     value::Float64
 end
 


### PR DESCRIPTION
The `@nonstruct` macro was missing in one of the examples. The code fails without it.