### PR TITLE
perf(make): cache target field tags

### DIFF
--- a/src/StructUtils.jl
+++ b/src/StructUtils.jl
@@ -145,11 +145,37 @@ function fieldtags end
 fieldtags(::StructStyle, T::Type)::NamedTuple{(),Tuple{}} = (;)
 
 function fieldtags(st::StructStyle, T::Type, field)
-    ft = fieldtags(st, T)
+    return _fieldtag(st, fieldtags(st, T), field)
+end
+
+function _fieldtag(st::StructStyle, ft, field)
     isempty(ft) && return (;)
-    fft = get(() -> (;), ft, field)
+    fft = get(ft, field, (;))
     ftk = fieldtagkey(st)
     return ftk === nothing ? fft : get(fft, ftk, fft)
+end
+
+@generated function _fieldtagtuple(st::StructStyle, ::Type{T}, fsyms) where {T}
+    n = fieldcount(T)
+    vals = [:(_fieldtag(st, ft, $(QuoteNode(fieldname(T, i))))) for i = 1:n]
+    return quote
+        Base.@_inline_meta
+        ft = fieldtags(st, T)
+        if isempty(ft)
+            return _fieldtagtuple_public(st, T, fsyms)
+        else
+            return ($(vals...),)
+        end
+    end
+end
+
+@generated function _fieldtagtuple_public(st::StructStyle, ::Type{T}, fsyms) where {T}
+    n = fieldcount(T)
+    vals = [:(fieldtags(st, T, $(QuoteNode(fieldname(T, i))))) for i = 1:n]
+    return quote
+        Base.@_inline_meta
+        return ($(vals...),)
+    end
 end
 
 """
@@ -1086,14 +1112,19 @@ end
     :($(Tuple(fieldname(T, i) for i in 1:fieldcount(T))))
 end
 
-struct StructClosure{T,A,S,FS,FSS}
+struct StructClosure{T,A,S,FS,FSS,FT}
     vals::A # Memory{Any} for structs, T for mutable structs
     style::S
     fsyms::FS
     fstrs::FSS
+    ftags::FT
 end
 
-StructClosure{T}(vals::A, style::S, fsyms::FS, fstrs::FSS) where {T,A,S,FS,FSS} = StructClosure{T,A,S,FS,FSS}(vals, style, fsyms, fstrs)
+StructClosure{T}(vals::A, style::S, fsyms::FS, fstrs::FSS) where {T,A,S,FS,FSS} =
+    StructClosure{T}(vals, style, fsyms, fstrs, _fieldtagtuple(style, T, fsyms))
+
+StructClosure{T}(vals::A, style::S, fsyms::FS, fstrs::FSS, ftags::FT) where {T,A,S,FS,FSS,FT} =
+    StructClosure{T,A,S,FS,FSS,FT}(vals, style, fsyms, fstrs, ftags)
 
 if VERSION < v"1.11"
     setval!(vals::Vector{Any}, x, i) = @inbounds vals[i] = x
@@ -1107,7 +1138,7 @@ function findfield(::Type{T}, k, v, f) where {T}
     st = _foreach(T) do i
         if typeof(k) == Symbol
             fn = f.fsyms[i]
-            ftags = fieldtags(f.style, T, fn)
+            ftags = f.ftags[i]
             field = get(ftags, :name, fn)
             if keyeq(k, field) || keyeq(k, fn)
                 symval, symst = make(f.style, fieldtype(T, i), v, ftags)
@@ -1116,7 +1147,7 @@ function findfield(::Type{T}, k, v, f) where {T}
             end
         elseif typeof(k) == Int
             if k == i
-                ftags = fieldtags(f.style, T, f.fsyms[i])
+                ftags = f.ftags[i]
                 intval, intst = make(f.style, fieldtype(T, i), v, ftags)
                 setval!(f.vals, intval, i)
                 return EarlyReturn(_MatchedState(intst))
@@ -1124,7 +1155,7 @@ function findfield(::Type{T}, k, v, f) where {T}
         else
             fn = f.fsyms[i]
             fstr = f.fstrs[i]
-            ftags = fieldtags(f.style, T, fn)
+            ftags = f.ftags[i]
             field = get(ftags, :name, fstr)
             if keyeq(k, field)
                 strval, strst = make(f.style, fieldtype(T, i), v, ftags)
@@ -1136,7 +1167,7 @@ function findfield(::Type{T}, k, v, f) where {T}
     return st isa _MatchedState ? st.value : unknownfield(f.style, T, k, v)
 end
 
-(f::StructClosure{T,A,S,FS,FSS})(k, v) where {T,A,S,FS,FSS} = findfield(T, k, v, f)
+(f::StructClosure{T,A,S,FS,FSS,FT})(k, v) where {T,A,S,FS,FSS,FT} = findfield(T, k, v, f)
 
 @inline makenoarg(style, ::Type{T}, source) where {T} = makenoarg(style, initialize(style, T, source), source)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,37 @@ end
 StructUtils.unknownfield(::StrictUnknownFieldStyle, ::Type{T}, key, value) where {T} =
     throw(UnknownFieldTestError(T, key))
 
+mutable struct CountingTagStyle <: StructUtils.StructStyle
+    calls::Int
+end
+
+struct CountingTagged
+    a::Int
+    b::Int
+    c::Int
+end
+
+function StructUtils.fieldtags(st::CountingTagStyle, ::Type{CountingTagged})
+    st.calls += 1
+    return (a=(name="a",), b=(name="b",), c=(name="c",))
+end
+
+mutable struct PerFieldTagStyle <: StructUtils.StructStyle
+    calls::Int
+end
+
+struct PerFieldTagged
+    x::Int
+    y::Int
+end
+
+function StructUtils.fieldtags(st::PerFieldTagStyle, ::Type{PerFieldTagged}, field)
+    st.calls += 1
+    field === :x && return (name="a",)
+    field === :y && return (name="b",)
+    return (;)
+end
+
 include(joinpath(dirname(pathof(StructUtils)), "../test/macros.jl"))
 include(joinpath(dirname(pathof(StructUtils)), "../test/struct.jl"))
 include(joinpath(dirname(pathof(StructUtils)), "../test/selectors.jl"))
@@ -158,6 +189,16 @@ println("Tuple")
     StructUtils.make!(pmut2, (id=0, name="Jane"); style=StrictUnknownFieldStyle())
     @test pmut2.id == 0 && pmut2.name == "Jane"
     @test_throws UnknownFieldTestError StructUtils.make!(pmut2, (id=0, name="Joan", rate=3.14); style=StrictUnknownFieldStyle())
+end
+
+@testset "target fieldtags are cached during make" begin
+    style = CountingTagStyle(0)
+    @test StructUtils.make(CountingTagged, (a=1, b=2, c=3), style) == CountingTagged(1, 2, 3)
+    @test style.calls == 1
+
+    perfield = PerFieldTagStyle(0)
+    @test StructUtils.make(PerFieldTagged, (a=10, b=20), perfield) == PerFieldTagged(10, 20)
+    @test perfield.calls == 2
 end
 
 println("C")


### PR DESCRIPTION
## Summary
- Cache per-target field tag metadata on `StructClosure` during `make`/`make!` struct materialization
- Reuse cached `ftags[i]` while matching incoming keys instead of recomputing `fieldtags(style, T, field)` for every candidate field
- Preserve the public per-field `fieldtags(style, T, field)` overload path when a style does not expose an all-field tag table

## Root cause
JSON typed parsing feeds object keys through StructUtils as lightweight key values. When target structs used `@tags`, `findfield` repeatedly fetched and filtered the full field tag table for every key/field comparison. On tagged JSON workloads this turned field matching into a large allocation and dispatch hotspot.

## Benchmarks
Using JSON v1.5.2 with this patched StructUtils in a temp env:

| Case | Before | After |
| --- | ---: | ---: |
| tagged Company MWE | `70.9 ms`, `604k allocs` | `2.79 ms`, `33k allocs` |
| wide 32-field `@tags`, 2k objects | `528.7 ms`, `4.2M allocs` | `5.84 ms`, `2k allocs` |

## Validation
- `julia --startup-file=no --project=. -e 'using Pkg; Pkg.test()'`\n- `Pkg.test("JSON")` in a temp env with JSON v1.5.2 and patched StructUtils v2.8.1\n