### PR TITLE
Add StructUtils trim compile workload

### DIFF
--- a/test/make_trim_safe.jl
+++ b/test/make_trim_safe.jl
@@ -1,6 +1,6 @@
 using StructUtils
+using StructUtils.Selectors: @selectors
 
-# Plain struct (no defaults)
 struct TrimA
     a::Int
     b::Int
@@ -8,7 +8,6 @@ struct TrimA
     d::Int
 end
 
-# Struct with simple defaults
 @defaults struct TrimB
     a::Int
     b::Int
@@ -16,68 +15,203 @@ end
     d::Int = 0
 end
 
-# Struct with computed/dependent defaults
 @defaults struct TrimC
     a::Int
     b::String = string(a)
 end
 
-# @kwarg struct with chained defaults
 @kwarg struct TrimD
     a::Int = 1
     b::Int = a + 10
     c::Int = a + b
 end
 
-# @noarg mutable struct
 @noarg mutable struct TrimE
     a::Int = 0
     b::Int = 0
 end
 
+@defaults struct TrimSimpleDefaults
+    a::Int = 1
+    b::String = "ok"
+end
+
+struct TrimStyle <: StructUtils.StructStyle end
+
+StructUtils.fieldtagkey(::TrimStyle) = :trim
+StructUtils.defaultstate(::TrimStyle) = :trim_state
+
+@nonstruct struct TrimPoint
+    x::Int
+    y::Int
+end
+
+function _trim_point(s::AbstractString)::TrimPoint
+    parts = split(s, ',')
+    return TrimPoint(parse(Int, parts[1]), parse(Int, parts[2]))
+end
+
+Base.convert(::Type{TrimPoint}, s::AbstractString) = _trim_point(s)
+StructUtils.lowerkey(::TrimStyle, p::TrimPoint) = "$(p.x),$(p.y)"
+StructUtils.liftkey(::TrimStyle, ::Type{TrimPoint}, s::AbstractString) = _trim_point(s)
+
+@tags struct TrimTagged
+    id::Int &(trim=(name="identifier",),)
+    code::Int
+    ignored::Int = 99 &(trim=(ignore=true,),)
+end
+
+abstract type TrimVehicle end
+
+struct TrimCarSource
+    seats::Int
+    wheels::Int
+end
+
+struct TrimTruckSource
+    payload::Int
+    axles::Int
+end
+
+struct TrimCar <: TrimVehicle
+    seats::Int
+    wheels::Int
+end
+
+struct TrimTruck <: TrimVehicle
+    payload::Int
+    axles::Int
+end
+
+trim_vehicle_type(::TrimCarSource) = TrimCar
+trim_vehicle_type(::TrimTruckSource) = TrimTruck
+
+StructUtils.@choosetype TrimVehicle trim_vehicle_type
+
+struct TrimSelectorRecord
+    key::Int
+    value::Int
+end
+
+@selectors TrimSelectorRecord
+
+function _assert_trim_public_traits()::Nothing
+    StructUtils.dictlike(Dict{Symbol,Int}) || error("dictlike")
+    StructUtils.arraylike(Vector{Int}) || error("arraylike vector")
+    StructUtils.arraylike((1, 2)) || error("arraylike tuple")
+    StructUtils.fixedsizearray(Matrix{Int}) || error("fixedsizearray")
+    StructUtils.structlike(StructUtils.DefaultStyle(), TrimTagged) || error("structlike")
+    StructUtils.noarg(StructUtils.DefaultStyle(), TrimE) || error("noarg")
+    StructUtils.kwarg(StructUtils.DefaultStyle(), TrimD) || error("kwarg")
+    StructUtils.nulllike(Nothing) || error("nulllike")
+    StructUtils.keyeq(:id, "id") || error("keyeq")
+    StructUtils.unknownfield(StructUtils.DefaultStyle(), TrimTagged, :extra, 1) === nothing || error("unknownfield")
+    StructUtils.fielddefault(TrimStyle(), TrimSimpleDefaults, :a) == 1 || error("fielddefault")
+    StructUtils.fielddefaults(TrimStyle(), TrimSimpleDefaults).b == "ok" || error("fielddefaults")
+    StructUtils.fieldtags(TrimStyle(), TrimTagged, :id).name == "identifier" || error("fieldtags")
+    StructUtils.discover_dims(StructUtils.DefaultStyle(), [1, 2, 3], 1) == (3,) || error("discover_dims")
+    return nothing
+end
+
+function _assert_trim_applyeach(tagged::TrimTagged)::Nothing
+    count = Ref(0)
+    saw_id = Ref(false)
+    saw_code = Ref(false)
+    ret = StructUtils.applyeach(TrimStyle(), tagged) do k, v
+        count[] += 1
+        if k == "identifier"
+            v == 1 || error("applyeach id")
+            saw_id[] = true
+        elseif k == :code
+            v == 7 || error("applyeach code")
+            saw_code[] = true
+        end
+        return nothing
+    end
+    ret === :trim_state || error("applyeach state")
+    count[] == 2 || error("applyeach count")
+    saw_id[] || error("applyeach id seen")
+    saw_code[] || error("applyeach code seen")
+
+    early = StructUtils.applyeach(TrimStyle(), tagged) do k, v
+        k == :code && return StructUtils.EarlyReturn(v)
+        return nothing
+    end
+    early isa StructUtils.EarlyReturn || error("EarlyReturn")
+    early.value == 7 || error("EarlyReturn value")
+    return nothing
+end
+
+function _assert_trim_selectors(tagged::TrimTagged)::Nothing
+    _ = tagged
+    record = TrimSelectorRecord(3, 7)
+    propertynames(record) == [:key, :value] || error("selector propertynames")
+    record.key == 3 || error("selector property")
+    record[:value] == 7 || error("selector getindex")
+    return nothing
+end
+
 function run_make_trim_sample()::Nothing
-    # 1. Plain struct from NamedTuple
+    _assert_trim_public_traits()
+
     a = StructUtils.make(TrimA, (a=1, b=2, c=3, d=4))
     a.a == 1 || error("TrimA.a")
     a.d == 4 || error("TrimA.d")
 
-    # 2. Plain struct from Dict{Symbol,Int} (homogeneous value type)
     a2 = StructUtils.make(TrimA, Dict{Symbol,Int}(:a => 1, :b => 2, :c => 3, :d => 4))
     a2.a == 1 || error("TrimA Dict")
 
-    # 3. Struct with defaults — all provided
     b1 = StructUtils.make(TrimB, (a=1, b=2, c=3, d=4))
     b1.c == 3 || error("TrimB all")
 
-    # 4. Struct with defaults — defaults used
     b2 = StructUtils.make(TrimB, (a=1, b=2))
     b2.c == 0 || error("TrimB defaults")
 
-    # 5. Computed defaults — default used
     c1 = StructUtils.make(TrimC, (a=42,))
     c1.b == "42" || error("TrimC computed")
 
-    # 6. Computed defaults — all provided
     c2 = StructUtils.make(TrimC, (a=42, b="hello"))
     c2.b == "hello" || error("TrimC provided")
 
-    # 7. Chained kwarg defaults
     d1 = StructUtils.make(TrimD, (a=5,))
     d1.b == 15 || error("TrimD.b")
     d1.c == 20 || error("TrimD.c")
 
-    # 8. @noarg mutable struct
     e = StructUtils.make(TrimE, (a=10, b=20))
     e.a == 10 || error("TrimE.a")
+    StructUtils.make!(e, (a=11, b=21))
+    e.b == 21 || error("make!")
+    StructUtils.reset!(e)
+    e.a == 0 || error("reset!")
 
-    # 9. NamedTuple target
     nt = StructUtils.make(@NamedTuple{a::Int, b::Int}, (a=1, b=2))
     nt.a == 1 || error("NamedTuple")
 
-    # 10. applyeach (serialization direction)
-    count = Ref(0)
-    StructUtils.applyeach(StructUtils.DefaultStyle(), (k, v) -> (count[] += 1; nothing), a)
-    count[] == 4 || error("applyeach")
+    vector = StructUtils.make(Vector{Int}, (1, 2, 3))
+    vector == [1, 2, 3] || error("Vector")
+
+    point_dict = StructUtils.make(Dict{TrimPoint, Int}, Dict("1,2" => 12), TrimStyle())
+    point_dict[TrimPoint(1, 2)] == 12 || error("liftkey")
+
+    tagged = StructUtils.make(
+        TrimTagged,
+        (identifier=1, code=7),
+        TrimStyle(),
+    )
+    tagged.id == 1 || error("TrimTagged id")
+    tagged.ignored == 99 || error("TrimTagged default")
+
+    _assert_trim_applyeach(tagged)
+    _assert_trim_selectors(tagged)
+
+    car = StructUtils.make(TrimVehicle, TrimCarSource(4, 4))
+    car == TrimCar(4, 4) || error("@choosetype car")
+
+    truck = StructUtils.make(TrimVehicle, TrimTruckSource(10, 3))
+    truck == TrimTruck(10, 3) || error("@choosetype truck")
+
+    scalar = StructUtils.make(TrimPoint, "8,9")
+    scalar == TrimPoint(8, 9) || error("@nonstruct lift")
 
     return nothing
 end

--- a/test/trim_compile_tests.jl
+++ b/test/trim_compile_tests.jl
@@ -3,6 +3,9 @@ using Test
 const _TRIM_SAFE_ERROR_BUDGET = 0
 const _TRIM_SUPPORTED = VERSION >= v"1.12.0-rc1"
 const _TRIM_PRE_RELEASE = !isempty(VERSION.prerelease)
+const _TRIM_COMPILE_TIMEOUT_S = Sys.iswindows() ? 600.0 : 120.0
+const _TRIM_EXECUTABLE_TIMEOUT_S = Sys.iswindows() ? 120.0 : 30.0
+const _TRIM_USE_BUNDLE = Sys.iswindows()
 const _JULIAC_ENTRYPOINT_EXPR = "using JuliaC; if isdefined(JuliaC, :main); JuliaC.main(ARGS); else JuliaC._main_cli(ARGS); end"
 
 # Pkg.test() sets JULIA_LOAD_PATH restrictively, which prevents subprocesses
@@ -11,11 +14,6 @@ const _JULIAC_ENTRYPOINT_EXPR = "using JuliaC; if isdefined(JuliaC, :main); Juli
 function _clean_cmd(cmd::Cmd)
     env = Dict{String,String}(k => v for (k, v) in ENV if k != "JULIA_LOAD_PATH")
     return setenv(cmd, env)
-end
-
-function _trim_use_bundle()::Bool
-    default = Sys.iswindows() ? "1" : "0"
-    return get(ENV, "STRUCTUTILS_TRIM_BUNDLE", default) == "1"
 end
 
 function _setup_trim_env()
@@ -47,7 +45,7 @@ function _setup_trim_env()
     return env_path
 end
 
-function _run_trim_compile(project_path::String, script_path::String, output_name::String; timeout_s::Float64 = 120.0, bundle_dir::Union{Nothing, String} = nothing)
+function _run_trim_compile(project_path::String, script_path::String, output_name::String; timeout_s::Float64 = _TRIM_COMPILE_TIMEOUT_S, bundle_dir::Union{Nothing, String} = nothing)
     julia_exe = joinpath(Sys.BINDIR, Base.julia_exename())
     cmd = if bundle_dir === nothing
         _clean_cmd(`$julia_exe --startup-file=no --history-file=no --code-coverage=none --project=$project_path -e $(_JULIAC_ENTRYPOINT_EXPR) -- --output-exe $output_name --project=$project_path --experimental --trim=safe $script_path`)
@@ -108,11 +106,6 @@ function _parse_trim_verify_totals(output::String)
     return parse(Int, m.captures[1]), parse(Int, m.captures[2])
 end
 
-function _trim_executable_timeout_s()::Float64
-    default = Sys.iswindows() ? "120.0" : "30.0"
-    return parse(Float64, get(ENV, "STRUCTUTILS_TRIM_EXE_TIMEOUT_S", default))
-end
-
 function _run_trim_case(project_path::String, script_file::String, output_name::String)
     script_path = joinpath(@__DIR__, script_file)
     @test isfile(script_path)
@@ -120,7 +113,7 @@ function _run_trim_case(project_path::String, script_file::String, output_name::
     start_t = time()
     mktempdir() do tmpdir
         cd(tmpdir) do
-            bundle_dir = _trim_use_bundle() ? joinpath(tmpdir, "bundle") : nothing
+            bundle_dir = _TRIM_USE_BUNDLE ? joinpath(tmpdir, "bundle") : nothing
             exit_code, output, timed_out = _run_trim_compile(project_path, script_path, output_name; bundle_dir = bundle_dir)
             if timed_out
                 println("[trim] compile TIMED OUT for $(script_file)")
@@ -134,21 +127,20 @@ function _run_trim_case(project_path::String, script_file::String, output_name::
             else
                 totals
             end
-            if get(ENV, "STRUCTUTILS_TRIM_PRINT_OUTPUT", "0") == "1" || trim_errors > 0
+            if trim_errors > 0 || trim_warnings > 0
                 println("---- trim compile output ($(script_file)) ----")
                 println(output)
                 println("---- end output ----")
             end
             @test trim_errors <= _TRIM_SAFE_ERROR_BUDGET
-            @test trim_warnings >= 0
+            @test trim_warnings == 0
             output_path = Sys.iswindows() ? "$(output_name).exe" : output_name
             if trim_errors == 0
                 run_path = bundle_dir === nothing ? output_path : joinpath(bundle_dir, "bin", output_path)
                 @test exit_code == 0
                 @test isfile(run_path)
-                run_timeout_s = _trim_executable_timeout_s()
                 run_cmd = `$(abspath(run_path))`
-                run_exit, run_output, run_timed_out = _run_command_with_timeout(run_cmd; timeout_s = run_timeout_s, log_label = "run")
+                run_exit, run_output, run_timed_out = _run_command_with_timeout(run_cmd; timeout_s = _TRIM_EXECUTABLE_TIMEOUT_S, log_label = "run")
                 if run_timed_out
                     println("[trim] executable TIMED OUT for $(script_file)")
                     println(run_output)


### PR DESCRIPTION
## Summary
- expand the JuliaC trim workload to cover StructUtils public entrypoints across construction, mutation, style hooks, selectors, tags, defaults, and type selection
- remove environment-variable configuration from the trim harness in favor of hard-coded platform timeouts and bundle behavior
- keep JuliaC setup inside the trim test so older Julia test jobs can still skip before resolving JuliaC

## Tests
- `julia --startup-file=no --project=. test/trim_compile_tests.jl`
- `julia --startup-file=no --project=. -e 'using Pkg; Pkg.test()'`

Co-authored by Codex
