### PR TITLE
Two-tier make: tier-0 field-table interpreter default, :hot opt-in, classic family deleted

### DIFF
--- a/Manifest-v1.12.toml
+++ b/Manifest-v1.12.toml
@@ -1,0 +1,66 @@
+# This file is machine-generated - editing it directly is not advised
+
+julia_version = "1.12.3"
+manifest_format = "2.0"
+project_hash = "5c85ae4be86611c61407771b22ae025ad0dcba67"
+
+[[deps.Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+version = "1.11.0"
+
+[[deps.PrecompileTools]]
+deps = ["Preferences"]
+git-tree-sha1 = "edbeefc7a4889f528644251bdb5fc9ab5348bc2c"
+uuid = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+version = "1.3.4"
+
+[[deps.Preferences]]
+deps = ["TOML"]
+git-tree-sha1 = "8b770b60760d4451834fe79dd483e318eee709c4"
+uuid = "21216c6a-2e73-6563-6e65-726566657250"
+version = "1.5.2"
+
+[[deps.Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+version = "1.11.0"
+
+[[deps.Random]]
+deps = ["SHA"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+version = "1.11.0"
+
+[[deps.SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+version = "0.7.0"
+
+[[deps.StructUtils]]
+deps = ["Dates", "PrecompileTools", "Preferences", "UUIDs"]
+path = "."
+uuid = "ec057cc2-7a8d-4b58-b3b3-92acb9f63b42"
+version = "2.8.2"
+
+    [deps.StructUtils.extensions]
+    StructUtilsMeasurementsExt = ["Measurements"]
+    StructUtilsStaticArraysCoreExt = ["StaticArraysCore"]
+    StructUtilsTablesExt = ["Tables"]
+
+    [deps.StructUtils.weakdeps]
+    Measurements = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
+    StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
+    Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
+
+[[deps.TOML]]
+deps = ["Dates"]
+uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+version = "1.0.3"
+
+[[deps.UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+version = "1.11.0"
+
+[[deps.Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+version = "1.11.0"

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,8 @@ version = "2.8.2"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+Preferences = "21216c6a-2e73-6563-6e65-726566657250"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [weakdeps]
@@ -17,6 +19,8 @@ StructUtilsStaticArraysCoreExt = ["StaticArraysCore"]
 StructUtilsTablesExt = ["Tables"]
 
 [compat]
+PrecompileTools = "1"
+Preferences = "1"
 Measurements = "2"
 StaticArraysCore = "1"
 Tables = "1"

--- a/src/StructUtils.jl
+++ b/src/StructUtils.jl
@@ -1297,6 +1297,7 @@ end
 
 include("selectors.jl")
 include("interp.jl")
+include("hot.jl")
 
 """
     StructUtils.@choosetype T func

--- a/src/StructUtils.jl
+++ b/src/StructUtils.jl
@@ -1,8 +1,18 @@
 module StructUtils
 
 using Dates, UUIDs
+using Preferences, PrecompileTools
 
 export @noarg, @defaults, @tags, @kwarg, @nonstruct, Selectors
+
+# Compile-time preference for `juliac --trim` builds: prunes the tier-0
+# interpreter's JIT-only arms (per-type metadata method consultation, dynamic
+# lift fallbacks, defaults-thunk re-evaluation) so the interpreter's call
+# graph is fully verifier-resolvable. This describes the build environment —
+# a no-JIT binary — not a behavior tier: parse results are identical, and
+# shapes outside the closed kind universe fail loudly at parse time instead
+# of falling back to dynamic dispatch that could not run anyway.
+const TRIM_BUILD = @load_preference("trim_build", false)::Bool
 
 """
     StructUtils.StructStyle
@@ -828,7 +838,9 @@ function make end
 
 function make(::Type{T}, source, style::StructStyle=DefaultStyle()) where {T}
     x, _ = make(style, T, source)
-    return x
+    # the assert makes results well-typed for callers even when the inner
+    # make ran through the non-specializing tier-0 interpreter
+    return x::T
 end
 
 if isdefined(Base, :delete) && applicable(Base.delete, (a=1,), :a)
@@ -965,6 +977,18 @@ function make(style::StructStyle, T::Type, source)
     elseif noarg(style, T)
         return makenoarg(style, T, source)
     elseif structlike(style, T)
+        # tier-0 interpreter: tree-shaped sources with an eligible field
+        # table construct through the non-specializing engine (one compiled
+        # instance per style/source shape, never per target type). In trim
+        # builds the routing is unconditional for tree sources: the runtime
+        # eligibility lookup can't constant-fold, and leaving the classic
+        # arms reachable from tree sources makes them verifier-unresolvable
+        # (ineligible types fail loudly inside the interpreter instead).
+        if TRIM_BUILD
+            _interpsource(source) && return _interp_make(style, T, source)
+        else
+            _interpready(style, T, source) && return _interp_make(style, T, source)
+        end
         return makestruct(style, T, source)
     else
         return lift(style, T, source)
@@ -1272,6 +1296,7 @@ function reset!(x::T; style::StructStyle=DefaultStyle()) where {T}
 end
 
 include("selectors.jl")
+include("interp.jl")
 
 """
     StructUtils.@choosetype T func
@@ -1336,6 +1361,21 @@ macro choosetype(style, T, ex)
             StructUtils.make(st, func(source), source)
         end
     end)
+end
+
+# exercises the tier-0 interpreter so its engine instances (per style/source
+# shape) live in this package's image; first typed `make` of any user struct
+# then pays table-build only
+@kwarg struct _InterpWorkload
+    a::Int = 0
+    b::Union{String,Nothing} = nothing
+    c::Vector{Float64} = Float64[]
+end
+
+@compile_workload begin
+    make(_InterpWorkload, Dict{String,Any}("a" => 1, "b" => "x", "c" => Any[1.0]))
+    make(_InterpWorkload, Dict{Symbol,Any}(:a => 2))
+    make(_InterpWorkload, ["a" => 3])
 end
 
 end

--- a/src/StructUtils.jl
+++ b/src/StructUtils.jl
@@ -987,11 +987,10 @@ function make(style::StructStyle, T::Type, source)
     elseif noarg(style, T) || structlike(style, T)
         # Struct-shaped targets: walkable sources go through the interpreter,
         # everything else through the per-type hot path (see the note at the
-        # top of this file). The gate must stay a runtime check — if the
-        # compiler could prove its answer at a call site it would delete one
-        # arm, and compiling `make` with an arm deleted has hung the compiler
-        # (the make functions are mutually recursive, and constant-folding
-        # inside that cycle doesn't terminate).
+        # top of this file). The gate is a runtime check the compiler cannot
+        # prove — the make functions are mutually recursive, and constant
+        # folding through that cycle does not terminate, so both arms must
+        # remain visible at every call site.
         if TRIM_BUILD
             _interpsource(source) && return _interp_make(style, T, source)
         else

--- a/src/StructUtils.jl
+++ b/src/StructUtils.jl
@@ -5,36 +5,44 @@ using Preferences, PrecompileTools
 
 export @noarg, @defaults, @tags, @kwarg, @nonstruct, Selectors
 
-# Compile-time preference for `juliac --trim` builds: prunes the tier-0
-# interpreter's JIT-only arms (per-type metadata method consultation, dynamic
-# lift fallbacks, defaults-thunk re-evaluation) so the interpreter's call
-# graph is fully verifier-resolvable. This describes the build environment —
-# a no-JIT binary — not a behavior tier: parse results are identical, and
-# shapes outside the closed kind universe fail loudly at parse time instead
-# of falling back to dynamic dispatch that could not run anyway.
+# Set `trim_build = true` in an app's LocalPreferences.toml when building it
+# with `juliac --trim`. A trimmed binary has no JIT, so any code path that
+# resolves methods at runtime cannot exist in it — this constant compiles
+# those paths out (looking up per-type metadata methods, generic `lift`
+# fallbacks, re-running default-value thunks). It describes the build
+# environment, not a behavior mode: results are identical, and the few
+# shapes that would have needed runtime dispatch throw a clear error at
+# parse time instead.
 const TRIM_BUILD = @load_preference("trim_build", false)::Bool
 
 # ── how `make` is organized ─────────────────────────────────────────────────
-# Three construction mechanisms share one public `make` surface; dispatch
-# picks between them, never a flag:
+# Two construction mechanisms share the public `make` surface. Which one runs
+# is decided by dispatch and a couple of runtime checks — there is no flag:
 #
-#   classic  (this file)   per-target-type closures driven by `applyeach`;
-#                          serves non-tree sources (NamedTuples, structs,
-#                          Tables rows) in JIT sessions. Compiles per target
-#                          type; not verifier-resolvable, so trim builds
-#                          never route here.
-#   tier-0   (interp.jl)   a non-specializing field-table interpreter for
-#                          tree-shaped sources (AbstractDict, Vector{<:Pair});
-#                          near-zero per-type compile cost, trim-verifiable
-#                          under the `trim_build` preference.
-#   hot      (hot.jl)      fully-specialized dispatchers (`::Type{T} where T`
-#                          everywhere), reachable via methods the struct
-#                          macros' `:hot` option emits — compiled into the
-#                          *defining package's* image through the hot-hook
-#                          registry — and, under `trim_build`, as the routing
-#                          target for every non-tree structlike make.
+#   interpreter  (interp.jl)  The default. Walks a per-type "field table"
+#                             (names, types, defaults, tags — built once and
+#                             cached) and fills fields by matching source
+#                             keys against it. The same compiled code handles
+#                             every target type, so a new struct costs a
+#                             table build, not a compile. Handles dict-like
+#                             and key/value-pair sources.
 #
-# The routing lives in the structlike arm of the 3-arg `make` below.
+#   hot          (hot.jl)     Fully compiled per target type — the fastest
+#                             steady-state path, at the cost of compiling
+#                             each type it touches. Runs when: a struct opts
+#                             in via the macros' `:hot` option (its code is
+#                             then compiled while the *defining package*
+#                             precompiles, so first use is fast), or when the
+#                             source isn't something the interpreter walks
+#                             (format-owned lazy values, Tables.jl rows).
+#
+# Container targets (Tuple/Array/Dict/Set) have their own builders further
+# down in this file; the interpreter reuses them for container-typed fields.
+#
+# Building a binary with `juliac --trim` requires one preference in the
+# app's project (`trim_build = true`). It compiles out the arms that resolve
+# methods at runtime — the trim verifier rejects those — leaving only code
+# whose call targets are known statically.
 # ────────────────────────────────────────────────────────────────────────────
 
 """
@@ -915,11 +923,11 @@ end
     return nothing
 end
 
-# shared Missing/Nothing/2-union peel prologue for the four make dispatchers
-# (classic and hot, 3- and 4-arg): `recurse` re-enters with the peeled type,
-# `extra...` carries trailing arguments (the tags NamedTuple for 4-arg forms).
-# Expects `style`, `T`, and `source` in scope; falls through when no peel
-# applies.
+# Shared prologue for the make dispatchers (3- and 4-arg, and their hot
+# counterparts): strips Missing/Nothing off union targets and splits 2-arm
+# unions, re-entering `recurse` with the narrowed type. `extra...` carries
+# trailing arguments (the tags NamedTuple for the 4-arg forms). Expects
+# `style`, `T`, and `source` in scope; falls through when nothing applies.
 macro _peel(recurse, extra...)
     esc(quote
         if T !== Any
@@ -976,26 +984,14 @@ function make(style::StructStyle, T::Type, source)
             r !== nothing && return r
         end
         return makearray(style, T, source)
-    elseif noarg(style, T)
-        # same tier routing as the structlike arm below
-        if TRIM_BUILD
-            _interpsource(source) && return _interp_make(style, T, source)
-        else
-            tbl = _interptable(style, T, source)
-            tbl !== nothing && return _interp_make(style, tbl, source)
-        end
-        return _hot_make3(style, T, source)
-    elseif structlike(style, T)
-        # struct targets route by tier (see the architecture note at the top
-        # of this file): eligible tree-shaped sources construct through the
-        # tier-0 interpreter — one engine instance per style, no per-type
-        # compile; everything else (lazy format sources, Tables.jl-style row
-        # sources, ineligible tables) takes the fully-specialized hot
-        # descent. The JIT gate stays a RUNTIME verdict (`_interpready`'s
-        # table lookup cannot const-fold): letting the source trait fold at
-        # a call site both invites a constprop spiral through the recursive
-        # make family and prunes arms the no-preference trim verification
-        # relies on seeing with narrow types.
+    elseif noarg(style, T) || structlike(style, T)
+        # Struct-shaped targets: walkable sources go through the interpreter,
+        # everything else through the per-type hot path (see the note at the
+        # top of this file). The gate must stay a runtime check — if the
+        # compiler could prove its answer at a call site it would delete one
+        # arm, and compiling `make` with an arm deleted has hung the compiler
+        # (the make functions are mutually recursive, and constant-folding
+        # inside that cycle doesn't terminate).
         if TRIM_BUILD
             _interpsource(source) && return _interp_make(style, T, source)
         else

--- a/src/StructUtils.jl
+++ b/src/StructUtils.jl
@@ -965,6 +965,15 @@ function make(style::StructStyle, T::Type, source)
     elseif arraylike(style, T)
         return makearray(style, T, source)
     elseif noarg(style, T)
+        # same tier routing as the structlike arm below: @noarg targets have
+        # interpreter tables too, and trim builds must not reach the classic
+        # closures from any arm
+        if TRIM_BUILD
+            _interpsource(source) && return _interp_make(style, T, source)
+            return _hot_make3(style, T, source)
+        else
+            _interpready(style, T, source) && return _interp_make(style, T, source)
+        end
         return makenoarg(style, T, source)
     elseif structlike(style, T)
         # struct targets route by tier (see the architecture note at the top

--- a/src/StructUtils.jl
+++ b/src/StructUtils.jl
@@ -14,6 +14,29 @@ export @noarg, @defaults, @tags, @kwarg, @nonstruct, Selectors
 # of falling back to dynamic dispatch that could not run anyway.
 const TRIM_BUILD = @load_preference("trim_build", false)::Bool
 
+# ── how `make` is organized ─────────────────────────────────────────────────
+# Three construction mechanisms share one public `make` surface; dispatch
+# picks between them, never a flag:
+#
+#   classic  (this file)   per-target-type closures driven by `applyeach`;
+#                          serves non-tree sources (NamedTuples, structs,
+#                          Tables rows) in JIT sessions. Compiles per target
+#                          type; not verifier-resolvable, so trim builds
+#                          never route here.
+#   tier-0   (interp.jl)   a non-specializing field-table interpreter for
+#                          tree-shaped sources (AbstractDict, Vector{<:Pair});
+#                          near-zero per-type compile cost, trim-verifiable
+#                          under the `trim_build` preference.
+#   hot      (hot.jl)      fully-specialized dispatchers (`::Type{T} where T`
+#                          everywhere), reachable via methods the struct
+#                          macros' `:hot` option emits — compiled into the
+#                          *defining package's* image through the hot-hook
+#                          registry — and, under `trim_build`, as the routing
+#                          target for every non-tree structlike make.
+#
+# The routing lives in the structlike arm of the 3-arg `make` below.
+# ────────────────────────────────────────────────────────────────────────────
+
 """
     StructUtils.StructStyle
 
@@ -873,30 +896,55 @@ end
 @inline abstractcollectionpassthrough(style::StructStyle, ::Type{T}, source) where {T} =
     isabstracttype(T) && source isa T && (dictlike(style, T) || arraylike(style, T))
 
+# two-component union disambiguation (exactly one arraylike member wins by
+# source shape) through the Union's builtin a/b fields: no runtime
+# `Base.uniontypes` vector, no generated expansion, and everything folds when
+# the target type is constant. Three-or-more components (a nested Union in
+# either slot) return `nothing` and the caller falls through.
+@inline function _union2(style::StructStyle, @nospecialize(T), source, recurse::R) where {R}
+    a = getfield(T, :a)
+    b = getfield(T, :b)
+    (a isa Union || b isa Union) && return nothing
+    a_arr = arraylike(style, a)
+    b_arr = arraylike(style, b)
+    if a_arr && !b_arr
+        return arraylike(style, source) ? recurse(a) : recurse(b)
+    elseif b_arr && !a_arr
+        return arraylike(style, source) ? recurse(b) : recurse(a)
+    end
+    return nothing
+end
+
+# shared Missing/Nothing/2-union peel prologue for the four make dispatchers
+# (classic and hot, 3- and 4-arg): `recurse` re-enters with the peeled type,
+# `extra...` carries trailing arguments (the tags NamedTuple for 4-arg forms).
+# Expects `style`, `T`, and `source` in scope; falls through when no peel
+# applies.
+macro _peel(recurse, extra...)
+    esc(quote
+        if T !== Any
+            if T >: Missing && T !== Missing
+                return nulllike(style, source) ?
+                       $recurse(style, Missing, source, $(extra...)) :
+                       $recurse(style, nonmissingtype(T), source, $(extra...))
+            elseif T >: Nothing && T !== Nothing
+                return nulllike(style, source) ?
+                       $recurse(style, Nothing, source, $(extra...)) :
+                       $recurse(style, Base.nonnothingtype(T), source, $(extra...))
+            end
+            if T isa Union
+                r = _union2(style, T, source, U -> $recurse(style, U, source, $(extra...)))
+                r !== nothing && return r
+            end
+        end
+    end)
+end
+
 function make(style::StructStyle, T::Type, source, tags)
     if haskey(tags, :choosetype)
         return make(style, tags.choosetype(source), source, _delete(tags, :choosetype))
     end
-    if T !== Any
-        if T >: Missing && T !== Missing
-            if nulllike(style, source)
-                return make(style, Missing, source, tags)
-            else
-                return make(style, nonmissingtype(T), source, tags)
-            end
-        elseif T >: Nothing && T !== Nothing
-            if nulllike(style, source)
-                return make(style, Nothing, source, tags)
-            else
-                return make(style, Base.nonnothingtype(T), source, tags)
-            end
-        end
-        # see _unionmake: unrolled two-component union disambiguation
-        if T isa Union
-            r = _unionmake(style, T, source, tags)
-            r !== nothing && return r
-        end
-    end
+    @_peel make tags
     if T <: Tuple || dictlike(style, T) || arraylike(style, T) || noarg(style, T) || structlike(style, T)
         return make(style, T, source)
     else
@@ -904,71 +952,12 @@ function make(style::StructStyle, T::Type, source, tags)
     end
 end
 
-# unrolls the arraylike-vs-scalar union disambiguation with literal component
-# types: `Base.uniontypes` builds a runtime Vector{Any}, which makes the
-# recursive `make` calls dynamic even when the target type constant-folds.
-# The rule can only ever match two-component unions ("exactly one arraylike
-# and one non-arraylike"), so anything else returns `nothing` (ambiguous) and
-# the caller falls through. The `arraylike` trait calls stay in the emitted
-# code — they are style-dependent — but fold at inference given the literal
-# types.
-@generated function _unionmake(style::StructStyle, ::Type{T}, source, tags) where {T}
-    types = Base.uniontypes(T)
-    length(types) == 2 || return :(return nothing)
-    A, B = types
-    return quote
-        a_arr = arraylike(style, $A)
-        b_arr = arraylike(style, $B)
-        if a_arr && !b_arr
-            return arraylike(style, source) ? make(style, $A, source, tags) : make(style, $B, source, tags)
-        elseif b_arr && !a_arr
-            return arraylike(style, source) ? make(style, $B, source, tags) : make(style, $A, source, tags)
-        end
-        return nothing
-    end
-end
-
-@generated function _unionmake(style::StructStyle, ::Type{T}, source) where {T}
-    types = Base.uniontypes(T)
-    length(types) == 2 || return :(return nothing)
-    A, B = types
-    return quote
-        a_arr = arraylike(style, $A)
-        b_arr = arraylike(style, $B)
-        if a_arr && !b_arr
-            return arraylike(style, source) ? make(style, $A, source) : make(style, $B, source)
-        elseif b_arr && !a_arr
-            return arraylike(style, source) ? make(style, $B, source) : make(style, $A, source)
-        end
-        return nothing
-    end
-end
 
 function make(style::StructStyle, T::Type, source)
     if abstractcollectionpassthrough(style, T, source)
         return source, defaultstate(style)
     end
-    # start with some hard-coded Union cases
-    if T !== Any
-        if T >: Missing && T !== Missing
-            if nulllike(style, source)
-                return make(style, Missing, source)
-            else
-                return make(style, nonmissingtype(T), source)
-            end
-        elseif T >: Nothing && T !== Nothing
-            if nulllike(style, source)
-                return make(style, Nothing, source)
-            else
-                return make(style, Base.nonnothingtype(T), source)
-            end
-        end
-        # see _unionmake: unrolled two-component union disambiguation
-        if T isa Union
-            r = _unionmake(style, T, source)
-            r !== nothing && return r
-        end
-    end
+    @_peel make
     if T <: Tuple
         return maketuple(style, T, source)
     elseif dictlike(style, T)
@@ -978,20 +967,14 @@ function make(style::StructStyle, T::Type, source)
     elseif noarg(style, T)
         return makenoarg(style, T, source)
     elseif structlike(style, T)
-        # tier-0 interpreter: tree-shaped sources with an eligible field
-        # table construct through the non-specializing engine (one compiled
-        # instance per style/source shape, never per target type). In trim
-        # builds the routing is unconditional for tree sources: the runtime
-        # eligibility lookup can't constant-fold, and leaving the classic
-        # arms reachable from tree sources makes them verifier-unresolvable
-        # (ineligible types fail loudly inside the interpreter instead).
+        # struct targets route by tier (see the architecture note at the top
+        # of this file): eligible tree-shaped sources construct through the
+        # tier-0 interpreter; under `trim_build` everything else takes the
+        # fully-specialized hot descent, because the classic closures below
+        # are never verifier-resolvable and every constprop'd call site must
+        # fold into a static path (`:hot` stays a JIT/precompile-time
+        # feature — trim correctness does not depend on annotation).
         if TRIM_BUILD
-            # tree-shaped sources interpret; everything else takes the hot
-            # (fully specialized) descent — the classic makestruct closures
-            # are never verifier-resolvable, so in a trim build every
-            # constprop'd call site must fold into a static path. The :hot
-            # annotation remains a JIT/precompile-time feature; trim
-            # correctness no longer depends on it.
             _interpsource(source) && return _interp_make(style, T, source)
             return _hot_make3(style, T, source)
         else

--- a/src/StructUtils.jl
+++ b/src/StructUtils.jl
@@ -5,6 +5,33 @@ using Preferences, PrecompileTools
 
 export @noarg, @defaults, @tags, @kwarg, @nonstruct, Selectors
 
+# The documented-but-unexported surface. Everything a format package needs
+# to drive the interpreter itself is declared here; the
+# leading-underscore names that remain are internal and may change.
+@static if VERSION >= v"1.11"
+    eval(Expr(:public,
+        :make, :make!, :reset!, :lift, :lower, :lowerkey, :liftkey,
+        :fieldtags, :fielddefaults, :custommake,
+        :dictlike, :arraylike, :structlike, :nulllike, :noarg,
+        :applyeach, :applylength, :initialize, :unknownfield, :keyeq,
+        :StructStyle, :DefaultStyle, :EarlyReturn, :defaultstate,
+        :fieldtagkey, :abstractcollectionpassthrough,
+        :fieldtable, :rootspec, :construct, :makevalue, :liftleaf,
+        :findspec, :allocvector,
+        :FieldTable, :FieldSpec, :ValueSpec,
+        :interpready, :interpsource, :register_fieldtable!,
+        :ishot, :register_hot_hook!, :hot_precompile!,
+        :TRIM_BUILD,
+        :KIND_UNSUPPORTED, :KIND_STRING, :KIND_INT64, :KIND_INT32,
+        :KIND_INT16, :KIND_INT8, :KIND_INT128, :KIND_UINT64, :KIND_UINT32,
+        :KIND_UINT16, :KIND_UINT8, :KIND_UINT128, :KIND_FLOAT64,
+        :KIND_FLOAT32, :KIND_FLOAT16, :KIND_BOOL, :KIND_DATE,
+        :KIND_DATETIME, :KIND_TIME, :KIND_UUID, :KIND_SYMBOL, :KIND_CHAR,
+        :KIND_ANY, :KIND_STRUCT, :KIND_VECTOR, :KIND_DICT, :KIND_UNION2,
+        :KIND_CUSTOM, :KIND_TUPLE, :KIND_FIXEDARRAY, :KIND_SETLIKE,
+    ))
+end
+
 # Set `trim_build = true` in an app's LocalPreferences.toml when building it
 # with `juliac --trim`. A trimmed binary has no JIT, so any code path that
 # resolves methods at runtime cannot exist in it — this constant compiles
@@ -182,6 +209,20 @@ using the StructUtils.jl macros: `@tags`, `@noarg`, `@defaults`, or `@kwarg`.
 Note this function returns the tags of *all* fields as a single NamedTuple.
 """
 function fieldtags end
+
+"""
+    StructUtils.custommake(::Type{T}) -> Bool
+
+Declare that `T` has its own `make` methods that must run whenever a value
+of type `T` is built — including when `T` appears as a field of another
+struct. Field values of such types are passed through full `make` dispatch
+instead of the field-table fast paths. `@choosetype` declares this
+automatically for its target type; declare it manually alongside any
+hand-written `make(::StructStyle, ::Type{T}, source)` method intended for
+field positions.
+"""
+custommake(::Type) = false
+
 
 fieldtags(::StructStyle, T::Type)::NamedTuple{(),Tuple{}} = (;)
 
@@ -1281,6 +1322,7 @@ x = StructUtils.make(Vehicle, Dict("type" => "car", "make" => "Toyota", "model" 
 """
 macro choosetype(T, ex)
     esc(quote
+        StructUtils.custommake(::Type{$T}) = true
         function StructUtils.make(st::StructUtils.StructStyle, ::Type{$T}, source, tags)
             func = $(ex)
             StructUtils.make(st, applicable(func, source, tags) ? func(source, tags) : func(source), source, tags)
@@ -1294,6 +1336,7 @@ end
 
 macro choosetype(style, T, ex)
     esc(quote
+        StructUtils.custommake(::Type{$T}) = true
         function StructUtils.make(st::$(style), ::Type{$T}, source, tags)
             func = $(ex)
             StructUtils.make(st, applicable(func, source, tags) ? func(source, tags) : func(source), source, tags)

--- a/src/StructUtils.jl
+++ b/src/StructUtils.jl
@@ -986,7 +986,14 @@ function make(style::StructStyle, T::Type, source)
         # arms reachable from tree sources makes them verifier-unresolvable
         # (ineligible types fail loudly inside the interpreter instead).
         if TRIM_BUILD
+            # tree-shaped sources interpret; everything else takes the hot
+            # (fully specialized) descent — the classic makestruct closures
+            # are never verifier-resolvable, so in a trim build every
+            # constprop'd call site must fold into a static path. The :hot
+            # annotation remains a JIT/precompile-time feature; trim
+            # correctness no longer depends on it.
             _interpsource(source) && return _interp_make(style, T, source)
+            return _hot_make3(style, T, source)
         else
             _interpready(style, T, source) && return _interp_make(style, T, source)
         end

--- a/src/StructUtils.jl
+++ b/src/StructUtils.jl
@@ -614,15 +614,20 @@ function applyeach(st::StructStyle, f, x::T) where {T}
                 ftags = fieldtags(st, T, $fname)
                 if !haskey(ftags, :ignore) || !ftags.ignore
                     fname = get(ftags, :name, $fname)
-                    ret = if isdefined(x, $i)
-                        f(lowerkey(st, fname), lower(st, getfield(x, $i), ftags))
+                    # hoist the value out of the three source branches so the
+                    # closure call is a single site with one φ argument —
+                    # keeps the call devirtualizable instead of three
+                    # branch-local calls with union-typed arguments
+                    val = if isdefined(x, $i)
+                        lower(st, getfield(x, $i), ftags)
                     elseif haskey(defs, $fname)
                         # this branch should be really rare because we should
                         # have applied a field default in the struct constructor
-                        f(lowerkey(st, fname), lower(st, defs[$fname], ftags))
+                        lower(st, defs[$fname], ftags)
                     else
-                        f(lowerkey(st, fname), lower(st, nothing, ftags))
+                        lower(st, nothing, ftags)
                     end
+                    ret = f(lowerkey(st, fname), val)
                     ret isa EarlyReturn && return ret
                 end
             end)
@@ -876,43 +881,56 @@ function make(style::StructStyle, T::Type, source, tags)
                 return make(style, Base.nonnothingtype(T), source, tags)
             end
         end
-        # for Union types like Union{T, Vector{T}} (after Nothing/Missing have been peeled),
-        # we can disambiguate by checking if source is arraylike;
-        # only applies when there's exactly one arraylike and one non-arraylike member
+        # see _unionmake: unrolled two-component union disambiguation
         if T isa Union
-            types = Base.uniontypes(T)
-            arr_type = nothing
-            scalar_type = nothing
-            ambiguous = false
-            for t in types
-                if arraylike(style, t)
-                    # more than one arraylike type means we can't disambiguate
-                    if arr_type !== nothing
-                        ambiguous = true
-                        break
-                    end
-                    arr_type = t
-                else
-                    if scalar_type !== nothing
-                        ambiguous = true
-                        break
-                    end
-                    scalar_type = t
-                end
-            end
-            if !ambiguous && arr_type !== nothing && scalar_type !== nothing
-                if arraylike(style, source)
-                    return make(style, arr_type, source, tags)
-                else
-                    return make(style, scalar_type, source, tags)
-                end
-            end
+            r = _unionmake(style, T, source, tags)
+            r !== nothing && return r
         end
     end
     if T <: Tuple || dictlike(style, T) || arraylike(style, T) || noarg(style, T) || structlike(style, T)
         return make(style, T, source)
     else
         return lift(style, T, source, tags)
+    end
+end
+
+# unrolls the arraylike-vs-scalar union disambiguation with literal component
+# types: `Base.uniontypes` builds a runtime Vector{Any}, which makes the
+# recursive `make` calls dynamic even when the target type constant-folds.
+# The rule can only ever match two-component unions ("exactly one arraylike
+# and one non-arraylike"), so anything else returns `nothing` (ambiguous) and
+# the caller falls through. The `arraylike` trait calls stay in the emitted
+# code — they are style-dependent — but fold at inference given the literal
+# types.
+@generated function _unionmake(style::StructStyle, ::Type{T}, source, tags) where {T}
+    types = Base.uniontypes(T)
+    length(types) == 2 || return :(return nothing)
+    A, B = types
+    return quote
+        a_arr = arraylike(style, $A)
+        b_arr = arraylike(style, $B)
+        if a_arr && !b_arr
+            return arraylike(style, source) ? make(style, $A, source, tags) : make(style, $B, source, tags)
+        elseif b_arr && !a_arr
+            return arraylike(style, source) ? make(style, $B, source, tags) : make(style, $A, source, tags)
+        end
+        return nothing
+    end
+end
+
+@generated function _unionmake(style::StructStyle, ::Type{T}, source) where {T}
+    types = Base.uniontypes(T)
+    length(types) == 2 || return :(return nothing)
+    A, B = types
+    return quote
+        a_arr = arraylike(style, $A)
+        b_arr = arraylike(style, $B)
+        if a_arr && !b_arr
+            return arraylike(style, source) ? make(style, $A, source) : make(style, $B, source)
+        elseif b_arr && !a_arr
+            return arraylike(style, source) ? make(style, $B, source) : make(style, $A, source)
+        end
+        return nothing
     end
 end
 
@@ -935,37 +953,10 @@ function make(style::StructStyle, T::Type, source)
                 return make(style, Base.nonnothingtype(T), source)
             end
         end
-        # for Union types like Union{T, Vector{T}} (after Nothing/Missing have been peeled),
-        # we can disambiguate by checking if source is arraylike;
-        # only applies when there's exactly one arraylike and one non-arraylike member
+        # see _unionmake: unrolled two-component union disambiguation
         if T isa Union
-            types = Base.uniontypes(T)
-            arr_type = nothing
-            scalar_type = nothing
-            ambiguous = false
-            for t in types
-                if arraylike(style, t)
-                    # more than one arraylike type means we can't disambiguate
-                    if arr_type !== nothing
-                        ambiguous = true
-                        break
-                    end
-                    arr_type = t
-                else
-                    if scalar_type !== nothing
-                        ambiguous = true
-                        break
-                    end
-                    scalar_type = t
-                end
-            end
-            if !ambiguous && arr_type !== nothing && scalar_type !== nothing
-                if arraylike(style, source)
-                    return make(style, arr_type, source)
-                else
-                    return make(style, scalar_type, source)
-                end
-            end
+            r = _unionmake(style, T, source)
+            r !== nothing && return r
         end
     end
     if T <: Tuple
@@ -1056,7 +1047,10 @@ struct DictClosure{T,S}
 end
 
 function (f::DictClosure{T,S})(k, v) where {T,S}
-    val, st = make(f.style, _valtype(f.dict), v)
+    # NTuple{2,Any} assert: an Any-valued target (e.g. Dict{String,Any}) makes
+    # the make() return type opaque, and destructuring an opaque value is
+    # dynamic dispatch under `juliac --trim`
+    val, st = make(f.style, _valtype(f.dict), v)::NTuple{2,Any}
     addkeyval!(f.dict, liftkey(f.style, _keytype(f.dict), k), val)
     return st
 end
@@ -1074,7 +1068,7 @@ struct ArrayClosure{T,S}
 end
 
 function (f::ArrayClosure{T,S})(_, v) where {T,S}
-    val, st = make(f.style, eltype(f.arr), v)
+    val, st = make(f.style, eltype(f.arr), v)::NTuple{2,Any}
     push!(f.arr, val)
     return st
 end
@@ -1086,7 +1080,7 @@ struct FixedArrayClosure{A,S}
 end
 
 function (f::FixedArrayClosure{A,S})(_, v) where {A,S}
-    val, st = make(f.style, eltype(f.arr), v)
+    val, st = make(f.style, eltype(f.arr), v)::NTuple{2,Any}
     i = f.idx[]
     @inbounds f.arr[i] = val
     f.idx[] = i + 1

--- a/src/StructUtils.jl
+++ b/src/StructUtils.jl
@@ -420,7 +420,22 @@ derived from lifting the value.
 """
 function lift end
 
-lift(::Type{Symbol}, x) = Symbol(x)
+function lift(::Type{Symbol}, @nospecialize(x))
+    # isa-laddered: the generic Symbol(x) funnels any reachable value type
+    # into string(x) — for BigFloat that is MPFR string formatting and for
+    # collections the array-show machinery, none of it trim-verifiable. The
+    # dynamic fallback stays for JIT sessions.
+    x isa Symbol && return x
+    x isa String && return Symbol(x::String)
+    if !TRIM_BUILD
+        # JIT-only: the abstract String(::AbstractString) constructor and the
+        # fully generic fallback (formats convert their string wrappers to
+        # String before lifting, so trim builds never need these)
+        x isa AbstractString && return Symbol(String(x))
+        return Symbol(x)
+    end
+    throw(ArgumentError("cannot lift a non-string value to Symbol in a trim build"))
+end
 lift(::Type{String}, x::Symbol) = String(x)
 lift(::Type{T}, x) where {T} = Base.issingletontype(T) ? T() : convert(T, x)
 lift(::Type{>:Missing}, ::Nothing) = missing

--- a/src/StructUtils.jl
+++ b/src/StructUtils.jl
@@ -614,20 +614,15 @@ function applyeach(st::StructStyle, f, x::T) where {T}
                 ftags = fieldtags(st, T, $fname)
                 if !haskey(ftags, :ignore) || !ftags.ignore
                     fname = get(ftags, :name, $fname)
-                    # hoist the value out of the three source branches so the
-                    # closure call is a single site with one φ argument —
-                    # keeps the call devirtualizable instead of three
-                    # branch-local calls with union-typed arguments
-                    val = if isdefined(x, $i)
-                        lower(st, getfield(x, $i), ftags)
+                    ret = if isdefined(x, $i)
+                        f(lowerkey(st, fname), lower(st, getfield(x, $i), ftags))
                     elseif haskey(defs, $fname)
                         # this branch should be really rare because we should
                         # have applied a field default in the struct constructor
-                        lower(st, defs[$fname], ftags)
+                        f(lowerkey(st, fname), lower(st, defs[$fname], ftags))
                     else
-                        lower(st, nothing, ftags)
+                        f(lowerkey(st, fname), lower(st, nothing, ftags))
                     end
-                    ret = f(lowerkey(st, fname), val)
                     ret isa EarlyReturn && return ret
                 end
             end)

--- a/src/StructUtils.jl
+++ b/src/StructUtils.jl
@@ -959,37 +959,50 @@ function make(style::StructStyle, T::Type, source)
     end
     @_peel make
     if T <: Tuple
+        if !TRIM_BUILD
+            r = _interp_root(style, T, source)
+            r !== nothing && return r
+        end
         return maketuple(style, T, source)
     elseif dictlike(style, T)
+        if !TRIM_BUILD
+            r = _interp_root(style, T, source)
+            r !== nothing && return r
+        end
         return makedict(style, T, source)
     elseif arraylike(style, T)
+        if !TRIM_BUILD && !fixedsizearray(style, T)
+            r = _interp_root(style, T, source)
+            r !== nothing && return r
+        end
         return makearray(style, T, source)
     elseif noarg(style, T)
-        # same tier routing as the structlike arm below: @noarg targets have
-        # interpreter tables too, and trim builds must not reach the classic
-        # closures from any arm
+        # same tier routing as the structlike arm below
         if TRIM_BUILD
             _interpsource(source) && return _interp_make(style, T, source)
-            return _hot_make3(style, T, source)
         else
-            _interpready(style, T, source) && return _interp_make(style, T, source)
+            tbl = _interptable(style, T, source)
+            tbl !== nothing && return _interp_make(style, tbl, source)
         end
-        return makenoarg(style, T, source)
+        return _hot_make3(style, T, source)
     elseif structlike(style, T)
         # struct targets route by tier (see the architecture note at the top
         # of this file): eligible tree-shaped sources construct through the
-        # tier-0 interpreter; under `trim_build` everything else takes the
-        # fully-specialized hot descent, because the classic closures below
-        # are never verifier-resolvable and every constprop'd call site must
-        # fold into a static path (`:hot` stays a JIT/precompile-time
-        # feature — trim correctness does not depend on annotation).
+        # tier-0 interpreter — one engine instance per style, no per-type
+        # compile; everything else (lazy format sources, Tables.jl-style row
+        # sources, ineligible tables) takes the fully-specialized hot
+        # descent. The JIT gate stays a RUNTIME verdict (`_interpready`'s
+        # table lookup cannot const-fold): letting the source trait fold at
+        # a call site both invites a constprop spiral through the recursive
+        # make family and prunes arms the no-preference trim verification
+        # relies on seeing with narrow types.
         if TRIM_BUILD
             _interpsource(source) && return _interp_make(style, T, source)
-            return _hot_make3(style, T, source)
         else
-            _interpready(style, T, source) && return _interp_make(style, T, source)
+            tbl = _interptable(style, T, source)
+            tbl !== nothing && return _interp_make(style, tbl, source)
         end
-        return makestruct(style, T, source)
+        return _hot_make3(style, T, source)
     else
         return lift(style, T, source)
     end
@@ -1139,20 +1152,6 @@ end
     :($(Tuple(fieldname(T, i) for i in 1:fieldcount(T))))
 end
 
-struct StructClosure{T,A,S,FS,FSS,FT}
-    vals::A # Memory{Any} for structs, T for mutable structs
-    style::S
-    fsyms::FS
-    fstrs::FSS
-    ftags::FT
-end
-
-StructClosure{T}(vals::A, style::S, fsyms::FS, fstrs::FSS) where {T,A,S,FS,FSS} =
-    StructClosure{T}(vals, style, fsyms, fstrs, _fieldtagtuple(style, T, fsyms))
-
-StructClosure{T}(vals::A, style::S, fsyms::FS, fstrs::FSS, ftags::FT) where {T,A,S,FS,FSS,FT} =
-    StructClosure{T,A,S,FS,FSS,FT}(vals, style, fsyms, fstrs, ftags)
-
 if VERSION < v"1.11"
     setval!(vals::Vector{Any}, x, i) = @inbounds vals[i] = x
 else
@@ -1160,50 +1159,6 @@ else
 end
 
 setval!(vals::T, x, i) where {T} = _setfield!(vals, i, x)
-
-function findfield(::Type{T}, k, v, f) where {T}
-    st = _foreach(T) do i
-        if typeof(k) == Symbol
-            fn = f.fsyms[i]
-            ftags = f.ftags[i]
-            field = get(ftags, :name, fn)
-            if keyeq(k, field) || keyeq(k, fn)
-                symval, symst = make(f.style, fieldtype(T, i), v, ftags)
-                setval!(f.vals, symval, i)
-                return EarlyReturn(_MatchedState(symst))
-            end
-        elseif typeof(k) == Int
-            if k == i
-                ftags = f.ftags[i]
-                intval, intst = make(f.style, fieldtype(T, i), v, ftags)
-                setval!(f.vals, intval, i)
-                return EarlyReturn(_MatchedState(intst))
-            end
-        else
-            fn = f.fsyms[i]
-            fstr = f.fstrs[i]
-            ftags = f.ftags[i]
-            field = get(ftags, :name, fstr)
-            if keyeq(k, field)
-                strval, strst = make(f.style, fieldtype(T, i), v, ftags)
-                setval!(f.vals, strval, i)
-                return EarlyReturn(_MatchedState(strst))
-            end
-        end
-    end
-    return st isa _MatchedState ? st.value : unknownfield(f.style, T, k, v)
-end
-
-(f::StructClosure{T,A,S,FS,FSS,FT})(k, v) where {T,A,S,FS,FSS,FT} = findfield(T, k, v, f)
-
-@inline makenoarg(style, ::Type{T}, source) where {T} = makenoarg(style, initialize(style, T, source), source)
-
-function makenoarg(style, y::T, source) where {T}
-    fsyms = fieldnamesymbols(T)
-    fstrs = fieldnamestrings(T)
-    st = applyeach(style, StructClosure{T}(y, style, fsyms, fstrs), source)
-    return y, st
-end
 
 macro _v(i)
     esc(:(isassigned(vals, $i) ? @inbounds(vals[$i])::fieldtype(T, $i) : get(defs, @inbounds(fsyms[$i]), nothing)::fieldtype(T, $i)))
@@ -1223,18 +1178,6 @@ end
     return ex
 end
 
-function makestruct(style, ::Type{T}, source) where {T}
-    vals = mem(fieldcount(T))
-    fsyms = fieldnamesymbols(T)
-    fstrs = fieldnamestrings(T)
-    st = applyeach(style, StructClosure{T}(vals, style, fsyms, fstrs), source)
-    if T <: NamedTuple
-        return T(_tuple(T, vals, style)), st
-    else
-        return _construct(T, vals, style, fsyms), st
-    end
-end
-
 make!(x::T, source; style::StructStyle=DefaultStyle()) where {T} = make!(style, x, source)
 make!(::Type{T}, source; style::StructStyle=DefaultStyle()) where {T} = make!(style, T, source)
 
@@ -1244,7 +1187,7 @@ function make!(style::StructStyle, x::T, source) where {T}
     elseif arraylike(style, x)
         _, st = makearray(style, x, source)
     elseif noarg(style, x)
-        _, st = makenoarg(style, x, source)
+        _, st = _hot_makenoarg(style, x, source)
     else
         throw(ArgumentError("Type `$T` does not support in-place `make!`"))
     end

--- a/src/hot.jl
+++ b/src/hot.jl
@@ -134,7 +134,7 @@ HotStructClosure{T}(vals::A, style::S, fsyms::FS, fstrs::FSS) where {T,A,S,FS,FS
 
 # literal field indices and field types: the runtime-`i` closure form makes
 # `fieldtype(T, i)` abstract, funneling every recursive call through the
-# single generic instance — unresolvable under --trim (PR #62's findfield)
+# single generic instance — unresolvable under --trim (PR #62's lesson)
 @generated function _hot_findfield(::Type{T}, k, v, f) where {T}
     ex = Expr(:block)
     push!(ex.args, :(Base.@_inline_meta))

--- a/src/hot.jl
+++ b/src/hot.jl
@@ -120,21 +120,30 @@ end
 
 # ---------------- specialized closures ----------------
 
-struct HotStructClosure{T,A,S,FS,FSS,FT}
+struct HotStructClosure{T,A,S,FS,FSS,FT,CMF}
     vals::A # Memory{Any} for structs, the instance for noarg mutables
     style::S
     fsyms::FS
     fstrs::FSS
     ftags::FT
+    cmf::CMF # per-field: the type carries its own make methods (JIT only)
 end
 
 HotStructClosure{T}(vals::A, style::S, fsyms::FS, fstrs::FSS) where {T,A,S,FS,FSS} =
     (ftags = _fieldtagtuple(style, T, fsyms);
-     HotStructClosure{T,A,S,FS,FSS,typeof(ftags)}(vals, style, fsyms, fstrs, ftags))
+     cmf = TRIM_BUILD ? nothing : _custom_make_fields(T);
+     HotStructClosure{T,A,S,FS,FSS,typeof(ftags),typeof(cmf)}(vals, style, fsyms, fstrs, ftags, cmf))
 
 # literal field indices and field types: the runtime-`i` closure form makes
 # `fieldtype(T, i)` abstract, funneling every recursive call through the
-# single generic instance — unresolvable under --trim (PR #62's lesson)
+# single generic instance — unresolvable under --trim (PR #62's lesson).
+# Under JIT, fields whose type carries its OWN `make` methods (raw-capture
+# types like JSON's JSONText, @choosetype-emitted union overrides) dispatch
+# through the 4-arg `make` so those hooks fire before any union peel — the
+# classic closures' behavior. The verdict lives on the closure (f.cmf,
+# memoized per type in the runtime world — a generator's frozen world could
+# never see late-defined hooks). Trim builds emit the plain hot field: the
+# runtime methods() reflection behind the verdict is not verifier-safe.
 @generated function _hot_findfield(::Type{T}, k, v, f) where {T}
     ex = Expr(:block)
     push!(ex.args, :(Base.@_inline_meta))
@@ -145,7 +154,9 @@ HotStructClosure{T}(vals::A, style::S, fsyms::FS, fstrs::FSS) where {T,A,S,FS,FS
                 let fn = f.fsyms[$i], ftags = f.ftags[$i]
                     field = get(ftags, :name, fn)
                     if keyeq(k, field) || keyeq(k, fn)
-                        symval, symst = _hot_field(f.style, $ft, v, ftags)
+                        symval, symst = TRIM_BUILD ? _hot_field(f.style, $ft, v, ftags) :
+                            (f.cmf[$i] ? _make_override(f.style, $ft, v, ftags) :
+                                         _hot_field(f.style, $ft, v, ftags))
                         setval!(f.vals, symval, $i)
                         return symst
                     end
@@ -153,7 +164,9 @@ HotStructClosure{T}(vals::A, style::S, fsyms::FS, fstrs::FSS) where {T,A,S,FS,FS
             elseif typeof(k) == Int
                 if k == $i
                     let ftags = f.ftags[$i]
-                        intval, intst = _hot_field(f.style, $ft, v, ftags)
+                        intval, intst = TRIM_BUILD ? _hot_field(f.style, $ft, v, ftags) :
+                            (f.cmf[$i] ? _make_override(f.style, $ft, v, ftags) :
+                                         _hot_field(f.style, $ft, v, ftags))
                         setval!(f.vals, intval, $i)
                         return intst
                     end
@@ -162,7 +175,9 @@ HotStructClosure{T}(vals::A, style::S, fsyms::FS, fstrs::FSS) where {T,A,S,FS,FS
                 let fstr = f.fstrs[$i], ftags = f.ftags[$i]
                     field = get(ftags, :name, fstr)
                     if keyeq(k, field)
-                        strval, strst = _hot_field(f.style, $ft, v, ftags)
+                        strval, strst = TRIM_BUILD ? _hot_field(f.style, $ft, v, ftags) :
+                            (f.cmf[$i] ? _make_override(f.style, $ft, v, ftags) :
+                                         _hot_field(f.style, $ft, v, ftags))
                         setval!(f.vals, strval, $i)
                         return strst
                     end
@@ -174,7 +189,15 @@ HotStructClosure{T}(vals::A, style::S, fsyms::FS, fstrs::FSS) where {T,A,S,FS,FS
     return ex
 end
 
-(f::HotStructClosure{T,A,S,FS,FSS,FT})(k, v) where {T,A,S,FS,FSS,FT} = _hot_findfield(T, k, v, f)
+# inference barrier for the custom-make field arm: called with a CONST field
+# type from the generated closure, a raw `make` invocation invites the
+# constprop/irinterp spiral through the recursive make family (the
+# interpsource lesson); the widened shared instance dispatches at runtime,
+# where the user's override wins by ordinary specificity
+Base.@nospecializeinfer @noinline _make_override(style::StructStyle, @nospecialize(T::Type), @nospecialize(source), @nospecialize(tags)) =
+    make(style, T, source, tags)
+
+(f::HotStructClosure{T,A,S,FS,FSS,FT,CMF})(k, v) where {T,A,S,FS,FSS,FT,CMF} = _hot_findfield(T, k, v, f)
 
 struct HotArrayClosure{T,S}
     arr::T

--- a/src/hot.jl
+++ b/src/hot.jl
@@ -29,13 +29,15 @@ const HOT_HOOKS = Any[]
 Register a format-side precompile hook. During downstream package
 precompilation, each `:hot`-annotated struct definition calls
 `f(T, samples::Tuple)` inside a newly-inferred-tagging block, so everything
-the hook compiles (e.g. a typed JSON parse of `T`) is cached in the defining
+the hook compiles (a format's typed parse of `T`, say) is cached in the defining
 package's image. Register from `__init__` (the registry is runtime state).
 Hooks must swallow their own errors.
 """
 register_hot_hook!(@nospecialize(f)) = (push!(HOT_HOOKS, f); nothing)
 
-function _hot_precompile!(@nospecialize(T::Type), samples::Tuple=(); force::Bool=false)
+# run the registered hooks for a `:hot` type — during precompilation of the
+# defining package normally, or immediately under `force` (the test path)
+function hot_precompile!(@nospecialize(T::Type), samples::Tuple=(); force::Bool=false)
     if force
         # test path: run the hooks without precompile tagging
         _hot_workload(T, samples)
@@ -58,6 +60,7 @@ function _hot_precompile!(@nospecialize(T::Type), samples::Tuple=(); force::Bool
     return nothing
 end
 
+# the compile workload itself: a tree-source make plus every registered hook
 function _hot_workload(@nospecialize(T::Type), samples::Tuple)
     try
         # baseline: compile the tree descent; a required-field error is
@@ -91,6 +94,8 @@ function _hot_field(style::StructStyle, ::Type{T}, source, tags) where {T}
     end
 end
 
+# the per-type 3-arg make: same trait ladder as the generic dispatcher,
+# every arm specialized on T
 function _hot_make3(style::StructStyle, ::Type{T}, source) where {T}
     if abstractcollectionpassthrough(style, T, source)
         return source, defaultstate(style)
@@ -127,16 +132,20 @@ struct HotStructClosure{T,A,S,FS,FSS,FT,CMF}
     cmf::CMF # per-field: the type carries its own make methods (JIT only)
 end
 
-HotStructClosure{T}(vals::A, style::S, fsyms::FS, fstrs::FSS) where {T,A,S,FS,FSS} =
-    (ftags = _fieldtagtuple(style, T, fsyms);
-     cmf = TRIM_BUILD ? nothing : _custom_make_fields(T);
-     HotStructClosure{T,A,S,FS,FSS,typeof(ftags),typeof(cmf)}(vals, style, fsyms, fstrs, ftags, cmf))
+# the cmf tuple records, per field, whether the field's type declares its
+# own make methods (`custommake`); with `T` concrete these trait calls fold
+# to constants when this constructor compiles
+function HotStructClosure{T}(vals::A, style::S, fsyms::FS, fstrs::FSS) where {T,A,S,FS,FSS}
+    ftags = _fieldtagtuple(style, T, fsyms)
+    cmf = TRIM_BUILD ? nothing : ntuple(i -> custommake(fieldtype(T, i)), Val(fieldcount(T)))
+    return HotStructClosure{T,A,S,FS,FSS,typeof(ftags),typeof(cmf)}(vals, style, fsyms, fstrs, ftags, cmf)
+end
 
 # Generated so each field gets a literal index and a literal field type —
 # looping over `i` at runtime would make `fieldtype(T, i)` abstract, and an
 # abstractly-typed field call cannot be compiled ahead of time for trimmed
 # binaries. Two dispatch paths per field: types with their OWN `make`
-# methods (raw-capture types like JSON's JSONText, `@choosetype` overrides)
+# methods (raw-capture types, `@choosetype` overrides — see `custommake`)
 # must go through the 4-arg `make` so those hooks fire before any union
 # handling; everything else takes the direct field path. That verdict rides
 # the closure (f.cmf) rather than being decided here, because this
@@ -198,6 +207,7 @@ Base.@nospecializeinfer @noinline _make_override(style::StructStyle, @nospeciali
 
 (f::HotStructClosure{T,A,S,FS,FSS,FT,CMF})(k, v) where {T,A,S,FS,FSS,FT,CMF} = _hot_findfield(T, k, v, f)
 
+# applyeach closure appending made elements to an array
 struct HotArrayClosure{T,S}
     arr::T
     style::S
@@ -209,6 +219,7 @@ function (f::HotArrayClosure{T,S})(_, v) where {T,S}
     return st
 end
 
+# applyeach closure inserting made key/value pairs into a dict
 struct HotDictClosure{T,S}
     dict::T
     style::S
@@ -220,6 +231,7 @@ function (f::HotDictClosure{T,S})(k, v) where {T,S}
     return st
 end
 
+# struct targets: fill a slot buffer via the field closure, then construct
 function _hot_makestruct(style::StructStyle, ::Type{T}, source) where {T}
     vals = mem(fieldcount(T))
     fsyms = fieldnamesymbols(T)
@@ -232,6 +244,7 @@ function _hot_makestruct(style::StructStyle, ::Type{T}, source) where {T}
     end
 end
 
+# mutable targets: set fields on the given instance via the field closure
 function _hot_makenoarg(style::StructStyle, y::T, source) where {T}
     fsyms = fieldnamesymbols(T)
     fstrs = fieldnamestrings(T)
@@ -239,6 +252,7 @@ function _hot_makenoarg(style::StructStyle, y::T, source) where {T}
     return y, st
 end
 
+# array targets: append each made element
 function _hot_makearray(style::StructStyle, x::T, source) where {T}
     st = applyeach(style, HotArrayClosure(x, style), source)
     return x, st
@@ -247,6 +261,7 @@ end
 _hot_makedict(style::StructStyle, ::Type{T}, source) where {T} =
     _hot_makedict(style, initialize(style, T, source), source)
 
+# dict targets: insert each made key/value pair
 function _hot_makedict(style::StructStyle, dict::T, source) where {T}
     st = applyeach(style, HotDictClosure(dict, style), source)
     return dict, st
@@ -263,6 +278,7 @@ function _hot_entry(style::StructStyle, ::Type{T}, source) where {T}
     return _hot_make3(style, T, source)
 end
 
+# 4-arg entry: resolve a choosetype tag first, then route as above
 function _hot_entry(style::StructStyle, ::Type{T}, source, tags) where {T}
     if haskey(tags, :choosetype)
         return make(style, tags.choosetype(source), source, _delete(tags, :choosetype))
@@ -282,7 +298,7 @@ you don't own — vendored API types being the typical case). Equivalent to
 defining the struct with `@kwarg :hot struct ...`: emits fully-specialized
 `make` methods for `T` and triggers precompile-time compilation through the
 hot-hook registry. Optional sample strings are handed to format hooks (e.g.
-JSON parses each sample against `T` during precompilation).
+a format package parses each sample against `T` during precompilation).
 """
 macro hot(T, samples...)
     ex = Expr(:block,

--- a/src/hot.jl
+++ b/src/hot.jl
@@ -3,11 +3,13 @@
 # `@hot`). Every dispatcher here carries `::Type{T} where T` — the forced
 # per-type specialization PR #62 gated globally behind a preference — but
 # scoped to annotated types, so nobody else pays the compile time. The
-# emitted entry tree-gates first: tree-shaped sources always take the tier-0
-# interpreter (faster at that size, and interpretable in trimmed binaries),
-# while the hot descent owns non-tree sources (format lazy values,
+# emitted entry tree-gates first: eligible tree-shaped sources take the
+# tier-0 interpreter (faster at request sizes, and interpretable in trimmed
+# binaries), while the hot descent owns everything else (format lazy values,
 # NamedTuples, structs) with a statically-resolvable call graph — no
-# preference required for `juliac --trim`.
+# preference required for `juliac --trim`. Under `trim_build` the make
+# dispatcher also routes *unannotated* non-tree structlike targets here; see
+# the architecture note at the top of StructUtils.jl.
 
 """
     StructUtils.ishot(T) -> Bool
@@ -18,14 +20,6 @@ at package-precompile time through the hot-hook registry.
 """
 ishot(@nospecialize(T)) = false
 
-"""
-    StructUtils.interpready(style, T) -> Bool
-
-`true` when the tier-0 interpreter has an eligible field table for `T` under
-`style` — i.e. a tree-shaped `make` will construct through the interpreter.
-"""
-interpready(style::StructStyle, @nospecialize(T::Type)) =
-    T isa DataType && fieldtable(T, style).eligible
 
 # ---------------- hot-hook registry ----------------
 
@@ -84,39 +78,6 @@ end
 
 # ---------------- specialized dispatchers (per-T `where T` throughout) ----------------
 
-# 2-component-union disambiguation with literal component types (a runtime
-# Base.uniontypes loop makes the recursive calls dynamic)
-@generated function _hot_unionmake(style::StructStyle, ::Type{T}, source, tags) where {T}
-    types = Base.uniontypes(T)
-    length(types) == 2 || return :(return nothing)
-    A, B = types
-    return quote
-        a_arr = arraylike(style, $A)
-        b_arr = arraylike(style, $B)
-        if a_arr && !b_arr
-            return arraylike(style, source) ? _hot_field(style, $A, source, tags) : _hot_field(style, $B, source, tags)
-        elseif b_arr && !a_arr
-            return arraylike(style, source) ? _hot_field(style, $B, source, tags) : _hot_field(style, $A, source, tags)
-        end
-        return nothing
-    end
-end
-
-@generated function _hot_unionmake(style::StructStyle, ::Type{T}, source) where {T}
-    types = Base.uniontypes(T)
-    length(types) == 2 || return :(return nothing)
-    A, B = types
-    return quote
-        a_arr = arraylike(style, $A)
-        b_arr = arraylike(style, $B)
-        if a_arr && !b_arr
-            return arraylike(style, source) ? _hot_make3(style, $A, source) : _hot_make3(style, $B, source)
-        elseif b_arr && !a_arr
-            return arraylike(style, source) ? _hot_make3(style, $B, source) : _hot_make3(style, $A, source)
-        end
-        return nothing
-    end
-end
 
 # field-level entry: the 4-arg `make` semantics with a specializing signature
 function _hot_field(style::StructStyle, ::Type{T}, source, tags) where {T}
@@ -124,25 +85,7 @@ function _hot_field(style::StructStyle, ::Type{T}, source, tags) where {T}
         # runtime-chosen types re-enter the generic machinery
         return make(style, tags.choosetype(source), source, _delete(tags, :choosetype))
     end
-    if T !== Any
-        if T >: Missing && T !== Missing
-            if nulllike(style, source)
-                return _hot_field(style, Missing, source, tags)
-            else
-                return _hot_field(style, nonmissingtype(T), source, tags)
-            end
-        elseif T >: Nothing && T !== Nothing
-            if nulllike(style, source)
-                return _hot_field(style, Nothing, source, tags)
-            else
-                return _hot_field(style, Base.nonnothingtype(T), source, tags)
-            end
-        end
-        if T isa Union
-            r = _hot_unionmake(style, T, source, tags)
-            r !== nothing && return r
-        end
-    end
+    @_peel _hot_field tags
     if T <: Tuple || dictlike(style, T) || arraylike(style, T) || noarg(style, T) || structlike(style, T)
         return _hot_make3(style, T, source)
     else
@@ -154,25 +97,7 @@ function _hot_make3(style::StructStyle, ::Type{T}, source) where {T}
     if abstractcollectionpassthrough(style, T, source)
         return source, defaultstate(style)
     end
-    if T !== Any
-        if T >: Missing && T !== Missing
-            if nulllike(style, source)
-                return _hot_make3(style, Missing, source)
-            else
-                return _hot_make3(style, nonmissingtype(T), source)
-            end
-        elseif T >: Nothing && T !== Nothing
-            if nulllike(style, source)
-                return _hot_make3(style, Nothing, source)
-            else
-                return _hot_make3(style, Base.nonnothingtype(T), source)
-            end
-        end
-        if T isa Union
-            r = _hot_unionmake(style, T, source)
-            r !== nothing && return r
-        end
-    end
+    @_peel _hot_make3
     if T <: Tuple
         # tuple targets reuse the existing generated machinery
         return maketuple(style, T, source)
@@ -339,49 +264,13 @@ hot-hook registry. Optional sample strings are handed to format hooks (e.g.
 JSON parses each sample against `T` during precompilation).
 """
 macro hot(T, samples...)
-    esc(quote
-        StructUtils.ishot(::Type{<:$T}) = true
-        function StructUtils.make(style::StructUtils.StructStyle, ::Type{S}, source) where {S<:$T}
-            StructUtils._hot_entry(style, S, source)
-        end
-        function StructUtils.make(style::StructUtils.StructStyle, ::Type{S}, source, tags) where {S<:$T}
-            StructUtils._hot_entry(style, S, source, tags)
-        end
+    ex = Expr(:block,
         # reflection-only field table so eligible tree sources still take the
-        # interpreter (types defined via the struct macros register richer
-        # metadata at their own definition site)
-        StructUtils.register_fieldtable!($T)
-        StructUtils._hot_precompile!($T, ($(samples...),))
-        $T
-    end)
+        # interpreter (macro-defined types register richer metadata at their
+        # own definition site)
+        :(StructUtils.register_fieldtable!($T)),
+        _hot_exprs(T, samples...)...,
+        T)
+    return esc(ex)
 end
 
-"""
-    StructUtils.interptreesafe(style, T) -> Bool
-
-`true` when `T`'s field table — including nested struct and vector-element
-tables — contains no choosetype-tagged fields or abstract CUSTOM leaves.
-Those receive the raw source value in user functions, so formats that
-materialize an alternate tree representation for the interpreter (e.g. JSON
-parsing to `Object` instead of handing out lazy values) must keep such types
-on their classic path.
-"""
-interptreesafe(style::StructStyle, @nospecialize(T::Type)) =
-    _treesafe(style, T, Base.IdSet{Any}())
-
-function _treesafe(style::StructStyle, @nospecialize(T), seen::Base.IdSet{Any})::Bool
-    T in seen && return true
-    push!(seen, T)
-    T isa DataType || return true
-    tbl = fieldtable(T, style)
-    tbl.eligible || return true # routed classic anyway
-    tbl.treesafe || return false
-    for sp in tbl.specs
-        if sp.kind == KIND_STRUCT
-            _treesafe(style, sp.ft, seen) || return false
-        elseif sp.kind == KIND_VECTOR && sp.elkind == KIND_STRUCT
-            _treesafe(style, sp.elft, seen) || return false
-        end
-    end
-    return true
-end

--- a/src/hot.jl
+++ b/src/hot.jl
@@ -1,15 +1,13 @@
-# The :hot tier: a fully-specialized `make` family, reachable only through
-# methods emitted by the struct macros' `:hot` option (or the standalone
-# `@hot`). Every dispatcher here carries `::Type{T} where T` — the forced
-# per-type specialization PR #62 gated globally behind a preference — but
-# scoped to annotated types, so nobody else pays the compile time. The
-# emitted entry tree-gates first: eligible tree-shaped sources take the
-# tier-0 interpreter (faster at request sizes, and interpretable in trimmed
-# binaries), while the hot descent owns everything else (format lazy values,
-# NamedTuples, structs) with a statically-resolvable call graph — no
-# preference required for `juliac --trim`. Under `trim_build` the make
-# dispatcher also routes *unannotated* non-tree structlike targets here; see
-# the architecture note at the top of StructUtils.jl.
+# The hot tier: a `make` family that compiles a dedicated method for each
+# target type (`::Type{T} where T` throughout) — the fastest steady-state
+# path, paid for in compile time. A struct opts in through the macros' :hot
+# option (or the standalone `@hot`), which also compiles its parse/write
+# paths while the *defining package* precompiles, so first use is already
+# fast. Sources the interpreter doesn't walk (format-owned lazy values,
+# Tables.jl rows) also land here, whether or not the type opted in. Every
+# call target below is known statically, which is what `juliac --trim`
+# builds require; see the note at the top of StructUtils.jl for the full
+# routing picture.
 
 """
     StructUtils.ishot(T) -> Bool
@@ -134,29 +132,34 @@ HotStructClosure{T}(vals::A, style::S, fsyms::FS, fstrs::FSS) where {T,A,S,FS,FS
      cmf = TRIM_BUILD ? nothing : _custom_make_fields(T);
      HotStructClosure{T,A,S,FS,FSS,typeof(ftags),typeof(cmf)}(vals, style, fsyms, fstrs, ftags, cmf))
 
-# literal field indices and field types: the runtime-`i` closure form makes
-# `fieldtype(T, i)` abstract, funneling every recursive call through the
-# single generic instance — unresolvable under --trim (PR #62's lesson).
-# Under JIT, fields whose type carries its OWN `make` methods (raw-capture
-# types like JSON's JSONText, @choosetype-emitted union overrides) dispatch
-# through the 4-arg `make` so those hooks fire before any union peel — the
-# classic closures' behavior. The verdict lives on the closure (f.cmf,
-# memoized per type in the runtime world — a generator's frozen world could
-# never see late-defined hooks). Trim builds emit the plain hot field: the
-# runtime methods() reflection behind the verdict is not verifier-safe.
+# Generated so each field gets a literal index and a literal field type —
+# looping over `i` at runtime would make `fieldtype(T, i)` abstract, and an
+# abstractly-typed field call cannot be compiled ahead of time for trimmed
+# binaries. Two dispatch paths per field: types with their OWN `make`
+# methods (raw-capture types like JSON's JSONText, `@choosetype` overrides)
+# must go through the 4-arg `make` so those hooks fire before any union
+# handling; everything else takes the direct field path. That verdict rides
+# the closure (f.cmf) rather than being decided here, because this
+# generator expands against the method table as of StructUtils load time
+# and would miss any hook defined later. Trim builds always emit the direct
+# path — the verdict relies on runtime method reflection, which a trimmed
+# binary doesn't have.
 @generated function _hot_findfield(::Type{T}, k, v, f) where {T}
     ex = Expr(:block)
     push!(ex.args, :(Base.@_inline_meta))
     for i = 1:fieldcount(T)
         ft = fieldtype(T, i)
+        # the per-field call: trim builds always take the direct path (see
+        # the comment above); JIT branches on the closure's verdict
+        fcall = TRIM_BUILD ? :(_hot_field(f.style, $ft, v, ftags)) :
+                :(f.cmf[$i] ? _make_override(f.style, $ft, v, ftags) :
+                              _hot_field(f.style, $ft, v, ftags))
         push!(ex.args, quote
             if typeof(k) == Symbol
                 let fn = f.fsyms[$i], ftags = f.ftags[$i]
                     field = get(ftags, :name, fn)
                     if keyeq(k, field) || keyeq(k, fn)
-                        symval, symst = TRIM_BUILD ? _hot_field(f.style, $ft, v, ftags) :
-                            (f.cmf[$i] ? _make_override(f.style, $ft, v, ftags) :
-                                         _hot_field(f.style, $ft, v, ftags))
+                        symval, symst = $fcall
                         setval!(f.vals, symval, $i)
                         return symst
                     end
@@ -164,9 +167,7 @@ HotStructClosure{T}(vals::A, style::S, fsyms::FS, fstrs::FSS) where {T,A,S,FS,FS
             elseif typeof(k) == Int
                 if k == $i
                     let ftags = f.ftags[$i]
-                        intval, intst = TRIM_BUILD ? _hot_field(f.style, $ft, v, ftags) :
-                            (f.cmf[$i] ? _make_override(f.style, $ft, v, ftags) :
-                                         _hot_field(f.style, $ft, v, ftags))
+                        intval, intst = $fcall
                         setval!(f.vals, intval, $i)
                         return intst
                     end
@@ -175,9 +176,7 @@ HotStructClosure{T}(vals::A, style::S, fsyms::FS, fstrs::FSS) where {T,A,S,FS,FS
                 let fstr = f.fstrs[$i], ftags = f.ftags[$i]
                     field = get(ftags, :name, fstr)
                     if keyeq(k, field)
-                        strval, strst = TRIM_BUILD ? _hot_field(f.style, $ft, v, ftags) :
-                            (f.cmf[$i] ? _make_override(f.style, $ft, v, ftags) :
-                                         _hot_field(f.style, $ft, v, ftags))
+                        strval, strst = $fcall
                         setval!(f.vals, strval, $i)
                         return strst
                     end
@@ -189,11 +188,12 @@ HotStructClosure{T}(vals::A, style::S, fsyms::FS, fstrs::FSS) where {T,A,S,FS,FS
     return ex
 end
 
-# inference barrier for the custom-make field arm: called with a CONST field
-# type from the generated closure, a raw `make` invocation invites the
-# constprop/irinterp spiral through the recursive make family (the
-# interpsource lesson); the widened shared instance dispatches at runtime,
-# where the user's override wins by ordinary specificity
+# The custom-make field arm calls `make` through this shim instead of
+# directly: with the field type a compile-time constant, the compiler tries
+# to evaluate its way through the mutually recursive make functions and
+# hangs. The shim's arguments are deliberately un-specialized, so it
+# compiles once and dispatches at runtime — where the user's method wins by
+# ordinary specificity.
 Base.@nospecializeinfer @noinline _make_override(style::StructStyle, @nospecialize(T::Type), @nospecialize(source), @nospecialize(tags)) =
     make(style, T, source, tags)
 
@@ -253,11 +253,10 @@ function _hot_makedict(style::StructStyle, dict::T, source) where {T}
     return dict, st
 end
 
-# entries targeted by the macro-emitted per-type `make` methods: eligible
-# trees take the interpreter (fast at that size, trim-clean via its own
-# story); the hot descent owns everything else with a static graph. The
-# eligibility check must live HERE — the interpreter's ineligible fallback
-# re-enters `make`, which would redispatch to the hot method forever.
+# Entry points for the per-type `make` methods the struct macros emit.
+# Even a `:hot` type prefers the interpreter when the source is walkable —
+# it's faster at typical sizes and works in trimmed binaries — so check
+# that here and fall through to the per-type descent for everything else.
 function _hot_entry(style::StructStyle, ::Type{T}, source) where {T}
     if _interpsource(source) && interpready(style, T)
         return _interp_make(style, T, source)

--- a/src/hot.jl
+++ b/src/hot.jl
@@ -188,12 +188,11 @@ HotStructClosure{T}(vals::A, style::S, fsyms::FS, fstrs::FSS) where {T,A,S,FS,FS
     return ex
 end
 
-# The custom-make field arm calls `make` through this shim instead of
-# directly: with the field type a compile-time constant, the compiler tries
-# to evaluate its way through the mutually recursive make functions and
-# hangs. The shim's arguments are deliberately un-specialized, so it
-# compiles once and dispatches at runtime — where the user's method wins by
-# ordinary specificity.
+# The custom-make field arm calls `make` through this shim: with the field
+# type a compile-time constant, constant folding through the mutually
+# recursive make functions does not terminate. The shim's un-specialized
+# arguments compile once and dispatch at runtime, where the user's method
+# wins by ordinary specificity.
 Base.@nospecializeinfer @noinline _make_override(style::StructStyle, @nospecialize(T::Type), @nospecialize(source), @nospecialize(tags)) =
     make(style, T, source, tags)
 

--- a/src/hot.jl
+++ b/src/hot.jl
@@ -1,0 +1,387 @@
+# The :hot tier: a fully-specialized `make` family, reachable only through
+# methods emitted by the struct macros' `:hot` option (or the standalone
+# `@hot`). Every dispatcher here carries `::Type{T} where T` — the forced
+# per-type specialization PR #62 gated globally behind a preference — but
+# scoped to annotated types, so nobody else pays the compile time. The
+# emitted entry tree-gates first: tree-shaped sources always take the tier-0
+# interpreter (faster at that size, and interpretable in trimmed binaries),
+# while the hot descent owns non-tree sources (format lazy values,
+# NamedTuples, structs) with a statically-resolvable call graph — no
+# preference required for `juliac --trim`.
+
+"""
+    StructUtils.ishot(T) -> Bool
+
+`true` when `T` was annotated `:hot` (e.g. `@kwarg :hot struct ...`) or via
+`StructUtils.@hot`. Hot types get fully-specialized `make` methods compiled
+at package-precompile time through the hot-hook registry.
+"""
+ishot(@nospecialize(T)) = false
+
+"""
+    StructUtils.interpready(style, T) -> Bool
+
+`true` when the tier-0 interpreter has an eligible field table for `T` under
+`style` — i.e. a tree-shaped `make` will construct through the interpreter.
+"""
+interpready(style::StructStyle, @nospecialize(T::Type)) =
+    T isa DataType && fieldtable(T, style).eligible
+
+# ---------------- hot-hook registry ----------------
+
+const HOT_HOOKS = Any[]
+
+"""
+    StructUtils.register_hot_hook!(f)
+
+Register a format-side precompile hook. During downstream package
+precompilation, each `:hot`-annotated struct definition calls
+`f(T, samples::Tuple)` inside a newly-inferred-tagging block, so everything
+the hook compiles (e.g. a typed JSON parse of `T`) is cached in the defining
+package's image. Register from `__init__` (the registry is runtime state).
+Hooks must swallow their own errors.
+"""
+register_hot_hook!(@nospecialize(f)) = (push!(HOT_HOOKS, f); nothing)
+
+function _hot_precompile!(@nospecialize(T::Type), samples::Tuple=(); force::Bool=false)
+    if force
+        # test path: run the hooks without precompile tagging
+        _hot_workload(T, samples)
+        return nothing
+    end
+    # workloads exist to seed pkgimages; in a `juliac --trim` compile session
+    # reachable-code compilation is juliac's job, and executing the workload
+    # would bake JIT-only instances into the image for the verifier to reject.
+    # The driver session's own JLOptions may not carry the trim flag, so we
+    # also honor the ecosystem env convention juliac builds already use.
+    Base.JLOptions().trim != 0 && return nothing
+    get(ENV, "JULIAC_DISABLE_PRECOMPILE_WORKLOADS", "0") == "1" && return nothing
+    Base.generating_output() || return nothing
+    # the workload wrapper tags newly-inferred instances so the *downstream*
+    # package's pkgimage retains them (bare execution during precompile
+    # drops external method instances)
+    @compile_workload begin
+        _hot_workload(T, samples)
+    end
+    return nothing
+end
+
+function _hot_workload(@nospecialize(T::Type), samples::Tuple)
+    try
+        # baseline: compile the tree descent; a required-field error is
+        # fine — matching and construction compile before the throw
+        make(T, Dict{String,Any}())
+    catch
+    end
+    for h in HOT_HOOKS
+        try
+            h(T, samples)
+        catch
+        end
+    end
+    return nothing
+end
+
+# ---------------- specialized dispatchers (per-T `where T` throughout) ----------------
+
+# 2-component-union disambiguation with literal component types (a runtime
+# Base.uniontypes loop makes the recursive calls dynamic)
+@generated function _hot_unionmake(style::StructStyle, ::Type{T}, source, tags) where {T}
+    types = Base.uniontypes(T)
+    length(types) == 2 || return :(return nothing)
+    A, B = types
+    return quote
+        a_arr = arraylike(style, $A)
+        b_arr = arraylike(style, $B)
+        if a_arr && !b_arr
+            return arraylike(style, source) ? _hot_field(style, $A, source, tags) : _hot_field(style, $B, source, tags)
+        elseif b_arr && !a_arr
+            return arraylike(style, source) ? _hot_field(style, $B, source, tags) : _hot_field(style, $A, source, tags)
+        end
+        return nothing
+    end
+end
+
+@generated function _hot_unionmake(style::StructStyle, ::Type{T}, source) where {T}
+    types = Base.uniontypes(T)
+    length(types) == 2 || return :(return nothing)
+    A, B = types
+    return quote
+        a_arr = arraylike(style, $A)
+        b_arr = arraylike(style, $B)
+        if a_arr && !b_arr
+            return arraylike(style, source) ? _hot_make3(style, $A, source) : _hot_make3(style, $B, source)
+        elseif b_arr && !a_arr
+            return arraylike(style, source) ? _hot_make3(style, $B, source) : _hot_make3(style, $A, source)
+        end
+        return nothing
+    end
+end
+
+# field-level entry: the 4-arg `make` semantics with a specializing signature
+function _hot_field(style::StructStyle, ::Type{T}, source, tags) where {T}
+    if haskey(tags, :choosetype)
+        # runtime-chosen types re-enter the generic machinery
+        return make(style, tags.choosetype(source), source, _delete(tags, :choosetype))
+    end
+    if T !== Any
+        if T >: Missing && T !== Missing
+            if nulllike(style, source)
+                return _hot_field(style, Missing, source, tags)
+            else
+                return _hot_field(style, nonmissingtype(T), source, tags)
+            end
+        elseif T >: Nothing && T !== Nothing
+            if nulllike(style, source)
+                return _hot_field(style, Nothing, source, tags)
+            else
+                return _hot_field(style, Base.nonnothingtype(T), source, tags)
+            end
+        end
+        if T isa Union
+            r = _hot_unionmake(style, T, source, tags)
+            r !== nothing && return r
+        end
+    end
+    if T <: Tuple || dictlike(style, T) || arraylike(style, T) || noarg(style, T) || structlike(style, T)
+        return _hot_make3(style, T, source)
+    else
+        return lift(style, T, source, tags)
+    end
+end
+
+function _hot_make3(style::StructStyle, ::Type{T}, source) where {T}
+    if abstractcollectionpassthrough(style, T, source)
+        return source, defaultstate(style)
+    end
+    if T !== Any
+        if T >: Missing && T !== Missing
+            if nulllike(style, source)
+                return _hot_make3(style, Missing, source)
+            else
+                return _hot_make3(style, nonmissingtype(T), source)
+            end
+        elseif T >: Nothing && T !== Nothing
+            if nulllike(style, source)
+                return _hot_make3(style, Nothing, source)
+            else
+                return _hot_make3(style, Base.nonnothingtype(T), source)
+            end
+        end
+        if T isa Union
+            r = _hot_unionmake(style, T, source)
+            r !== nothing && return r
+        end
+    end
+    if T <: Tuple
+        # tuple targets reuse the existing generated machinery
+        return maketuple(style, T, source)
+    elseif dictlike(style, T)
+        return _hot_makedict(style, T, source)
+    elseif arraylike(style, T)
+        if fixedsizearray(style, T)
+            # multidim/fixed-size arrays reuse the existing machinery
+            return makearray(style, T, source)
+        end
+        return _hot_makearray(style, initialize(style, T, source), source)
+    elseif noarg(style, T)
+        return _hot_makenoarg(style, initialize(style, T, source), source)
+    elseif structlike(style, T)
+        return _hot_makestruct(style, T, source)
+    else
+        return lift(style, T, source)
+    end
+end
+
+# ---------------- specialized closures ----------------
+
+struct HotStructClosure{T,A,S,FS,FSS,FT}
+    vals::A # Memory{Any} for structs, the instance for noarg mutables
+    style::S
+    fsyms::FS
+    fstrs::FSS
+    ftags::FT
+end
+
+HotStructClosure{T}(vals::A, style::S, fsyms::FS, fstrs::FSS) where {T,A,S,FS,FSS} =
+    (ftags = _fieldtagtuple(style, T, fsyms);
+     HotStructClosure{T,A,S,FS,FSS,typeof(ftags)}(vals, style, fsyms, fstrs, ftags))
+
+# literal field indices and field types: the runtime-`i` closure form makes
+# `fieldtype(T, i)` abstract, funneling every recursive call through the
+# single generic instance — unresolvable under --trim (PR #62's findfield)
+@generated function _hot_findfield(::Type{T}, k, v, f) where {T}
+    ex = Expr(:block)
+    push!(ex.args, :(Base.@_inline_meta))
+    for i = 1:fieldcount(T)
+        ft = fieldtype(T, i)
+        push!(ex.args, quote
+            if typeof(k) == Symbol
+                let fn = f.fsyms[$i], ftags = f.ftags[$i]
+                    field = get(ftags, :name, fn)
+                    if keyeq(k, field) || keyeq(k, fn)
+                        symval, symst = _hot_field(f.style, $ft, v, ftags)
+                        setval!(f.vals, symval, $i)
+                        return symst
+                    end
+                end
+            elseif typeof(k) == Int
+                if k == $i
+                    let ftags = f.ftags[$i]
+                        intval, intst = _hot_field(f.style, $ft, v, ftags)
+                        setval!(f.vals, intval, $i)
+                        return intst
+                    end
+                end
+            else
+                let fstr = f.fstrs[$i], ftags = f.ftags[$i]
+                    field = get(ftags, :name, fstr)
+                    if keyeq(k, field)
+                        strval, strst = _hot_field(f.style, $ft, v, ftags)
+                        setval!(f.vals, strval, $i)
+                        return strst
+                    end
+                end
+            end
+        end)
+    end
+    push!(ex.args, :(return unknownfield(f.style, T, k, v)))
+    return ex
+end
+
+(f::HotStructClosure{T,A,S,FS,FSS,FT})(k, v) where {T,A,S,FS,FSS,FT} = _hot_findfield(T, k, v, f)
+
+struct HotArrayClosure{T,S}
+    arr::T
+    style::S
+end
+
+function (f::HotArrayClosure{T,S})(_, v) where {T,S}
+    val, st = _hot_make3(f.style, eltype(f.arr), v)::NTuple{2,Any}
+    push!(f.arr, val)
+    return st
+end
+
+struct HotDictClosure{T,S}
+    dict::T
+    style::S
+end
+
+function (f::HotDictClosure{T,S})(k, v) where {T,S}
+    val, st = _hot_make3(f.style, _valtype(f.dict), v)::NTuple{2,Any}
+    addkeyval!(f.dict, liftkey(f.style, _keytype(f.dict), k), val)
+    return st
+end
+
+function _hot_makestruct(style::StructStyle, ::Type{T}, source) where {T}
+    vals = mem(fieldcount(T))
+    fsyms = fieldnamesymbols(T)
+    fstrs = fieldnamestrings(T)
+    st = applyeach(style, HotStructClosure{T}(vals, style, fsyms, fstrs), source)
+    if T <: NamedTuple
+        return T(_tuple(T, vals, style)), st
+    else
+        return _construct(T, vals, style, fsyms), st
+    end
+end
+
+function _hot_makenoarg(style::StructStyle, y::T, source) where {T}
+    fsyms = fieldnamesymbols(T)
+    fstrs = fieldnamestrings(T)
+    st = applyeach(style, HotStructClosure{T}(y, style, fsyms, fstrs), source)
+    return y, st
+end
+
+function _hot_makearray(style::StructStyle, x::T, source) where {T}
+    st = applyeach(style, HotArrayClosure(x, style), source)
+    return x, st
+end
+
+_hot_makedict(style::StructStyle, ::Type{T}, source) where {T} =
+    _hot_makedict(style, initialize(style, T, source), source)
+
+function _hot_makedict(style::StructStyle, dict::T, source) where {T}
+    st = applyeach(style, HotDictClosure(dict, style), source)
+    return dict, st
+end
+
+# entries targeted by the macro-emitted per-type `make` methods: eligible
+# trees take the interpreter (fast at that size, trim-clean via its own
+# story); the hot descent owns everything else with a static graph. The
+# eligibility check must live HERE — the interpreter's ineligible fallback
+# re-enters `make`, which would redispatch to the hot method forever.
+function _hot_entry(style::StructStyle, ::Type{T}, source) where {T}
+    if _interpsource(source) && interpready(style, T)
+        return _interp_make(style, T, source)
+    end
+    return _hot_make3(style, T, source)
+end
+
+function _hot_entry(style::StructStyle, ::Type{T}, source, tags) where {T}
+    if haskey(tags, :choosetype)
+        return make(style, tags.choosetype(source), source, _delete(tags, :choosetype))
+    end
+    if _interpsource(source) && interpready(style, T)
+        return _interp_make(style, T, source)
+    end
+    return _hot_make3(style, T, source)
+end
+
+"""
+    StructUtils.@hot T
+    StructUtils.@hot T "sample" ...
+
+Standalone `:hot` annotation for an existing struct type (including types
+you don't own — vendored API types being the typical case). Equivalent to
+defining the struct with `@kwarg :hot struct ...`: emits fully-specialized
+`make` methods for `T` and triggers precompile-time compilation through the
+hot-hook registry. Optional sample strings are handed to format hooks (e.g.
+JSON parses each sample against `T` during precompilation).
+"""
+macro hot(T, samples...)
+    esc(quote
+        StructUtils.ishot(::Type{<:$T}) = true
+        function StructUtils.make(style::StructUtils.StructStyle, ::Type{S}, source) where {S<:$T}
+            StructUtils._hot_entry(style, S, source)
+        end
+        function StructUtils.make(style::StructUtils.StructStyle, ::Type{S}, source, tags) where {S<:$T}
+            StructUtils._hot_entry(style, S, source, tags)
+        end
+        # reflection-only field table so eligible tree sources still take the
+        # interpreter (types defined via the struct macros register richer
+        # metadata at their own definition site)
+        StructUtils.register_fieldtable!($T)
+        StructUtils._hot_precompile!($T, ($(samples...),))
+        $T
+    end)
+end
+
+"""
+    StructUtils.interptreesafe(style, T) -> Bool
+
+`true` when `T`'s field table — including nested struct and vector-element
+tables — contains no choosetype-tagged fields or abstract CUSTOM leaves.
+Those receive the raw source value in user functions, so formats that
+materialize an alternate tree representation for the interpreter (e.g. JSON
+parsing to `Object` instead of handing out lazy values) must keep such types
+on their classic path.
+"""
+interptreesafe(style::StructStyle, @nospecialize(T::Type)) =
+    _treesafe(style, T, Base.IdSet{Any}())
+
+function _treesafe(style::StructStyle, @nospecialize(T), seen::Base.IdSet{Any})::Bool
+    T in seen && return true
+    push!(seen, T)
+    T isa DataType || return true
+    tbl = fieldtable(T, style)
+    tbl.eligible || return true # routed classic anyway
+    tbl.treesafe || return false
+    for sp in tbl.specs
+        if sp.kind == KIND_STRUCT
+            _treesafe(style, sp.ft, seen) || return false
+        elseif sp.kind == KIND_VECTOR && sp.elkind == KIND_STRUCT
+            _treesafe(style, sp.elft, seen) || return false
+        end
+    end
+    return true
+end

--- a/src/interp.jl
+++ b/src/interp.jl
@@ -19,7 +19,10 @@
 # default thunks — are compiled out, since a trimmed binary has no JIT to
 # run them. Types registered by the struct macros carry their defaults and
 # tags as plain data, so they parse through the interpreter in trimmed
-# binaries with nothing left to look up.
+# binaries with nothing left to look up. A value that would have needed one
+# of the compiled-out arms (a custom-kind field, an unregistered exotic
+# shape) raises a clear error at parse time naming the field, rather than
+# silently misbehaving.
 
 # closed kind universe; anything else is KIND_CUSTOM (dynamic lift, JIT-only)
 const KIND_UNSUPPORTED = Int8(0)
@@ -55,6 +58,7 @@ const KIND_TUPLE = Int8(29)
 const KIND_FIXEDARRAY = Int8(30)
 const KIND_SETLIKE = Int8(31)
 
+# kind tag for a scalar leaf type, or KIND_UNSUPPORTED
 function scalarkind(@nospecialize(ft))
     ft === String && return KIND_STRING
     ft === Int64 && return KIND_INT64
@@ -89,7 +93,7 @@ const FRESHEMPTY = FreshEmpty()
 struct ThunkDefault end        # mutable/aliasing-unsafe default: re-eval thunk (JIT only)
 const THUNKDEFAULT = ThunkDefault()
 
-# recursive description of what to produce at one JSON value position:
+# recursive description of what to produce at one source value position:
 # vector elements, dict values, and two-component-union arms nest as child
 # specs, so arbitrarily nested containers stay table-driven
 struct ValueSpec
@@ -104,6 +108,7 @@ struct ValueSpec
     child2::Any        # ::Union{Nothing,ValueSpec}: the non-arraylike union arm
 end
 
+# everything the interpreter knows about one field of a target struct
 struct FieldSpec
     name::String       # match name (post fieldtags rename)
     namesym::Symbol    # same, as Symbol, for Symbol-keyed sources
@@ -139,10 +144,6 @@ struct RawMeta
     defaultsthunk::Any   # () -> NamedTuple for aliasing-unsafe re-evaluation, or nothing
     tags::Any            # NamedTuple of fieldtags, or nothing
     nonstruct::Bool      # @nonstruct types lift as leaves, never field-parse
-    tagsmethods::Any     # Methods applicable to fieldtags(::StructStyle, ::Type{<:T})
-                         # at registration (the macro's emissions, incl.
-                         # parameterized forms, or the generic fallback)
-    defaultsmethods::Any # same, for fielddefaults
     valsdependent::Bool  # defaults reference other (parsed) fields
 end
 
@@ -160,6 +161,7 @@ struct MetaSnap
     tables::IdDict{Any,Vector{Pair{DataType,FieldTable}}}
 end
 
+# holds the current registry snapshot; writers swap it atomically
 mutable struct MetaStore
     @atomic snap::MetaSnap
 end
@@ -194,19 +196,13 @@ function register_fieldtable!(@nospecialize(T::Type); defaults=nothing, tags=not
             nothing
         end
     end
-    # capture which methods resolve this type's metadata right now (the
-    # macro-emitted ones, or the generic fallbacks): if a more specific or
-    # per-style overload appears later, table resolution detects the mismatch
-    # and rebuilds the table from the live methods instead
-    tm = _whichmeta(fieldtags, T)
-    dm = _whichmeta(fielddefaults, T)
     # explicit lock/unlock: a `lock() do` closure capturing @nospecialize
     # arguments is not verifier-resolvable
     lock(META_LOCK)
     try
         old = @atomic METASTORE.snap
         raw = copy(old.raw)
-        raw[T] = RawMeta(nt, defaults, tags, nonstruct, tm, dm, valsdependent)
+        raw[T] = RawMeta(nt, defaults, tags, nonstruct, valsdependent)
         tables = copy(old.tables)
         empty!(tables) # invalidate resolved tables (nested kinds may change)
         roots = copy(old.roots)
@@ -216,18 +212,6 @@ function register_fieldtable!(@nospecialize(T::Type); defaults=nothing, tags=not
         unlock(META_LOCK)
     end
     return nothing
-end
-
-_whichmeta(@nospecialize(f), @nospecialize(T)) = try
-    collect(methods(f, Tuple{StructStyle, Type{<:T}}))
-catch
-    nothing
-end
-
-_whichmeta_style(@nospecialize(f), @nospecialize(style), @nospecialize(T)) = try
-    which(f, Tuple{typeof(style), Type{T}})
-catch
-    nothing
 end
 
 # ---------------- table resolution ----------------
@@ -270,6 +254,7 @@ _vector_eltype(@nospecialize(ft)) = (getfield(ft, :parameters)::Core.SimpleVecto
 
 _vectype(@nospecialize(E)) = Core.apply_type(Vector, E)
 
+# kind tag for any declared field type (scalars, containers, structs, unions)
 function kindfor(@nospecialize(ft))
     k = scalarkind(ft)
     k != KIND_UNSUPPORTED && return k
@@ -312,15 +297,17 @@ function classify_default(@nospecialize(v))
     return THUNKDEFAULT
 end
 
-_rawmeta(snap::MetaSnap, @nospecialize(T)) = begin
+# registered metadata for T, or nothing
+function _rawmeta(snap::MetaSnap, @nospecialize(T))
     m = get(snap.raw, T, nothing)
     if m === nothing && T isa DataType
         # parametric structs register under their UnionAll wrapper
         m = get(snap.raw, getfield(getfield(T, :name), :wrapper), nothing)
     end
-    m
+    return m
 end
 
+# build the FieldTable for (T, style) from registered metadata or reflection
 function buildtable(@nospecialize(T::Type), style::StructStyle)
     T isa DataType ||
         return FieldTable(Nothing, false, FieldSpec[], false, false, nothing, false, false)
@@ -331,15 +318,14 @@ function buildtable(@nospecialize(T::Type), style::StructStyle)
     volatile = false
     valsdefaults = metaok && (meta::RawMeta).valsdependent
     if metaok && !TRIM_BUILD
-        # the registered data is only valid while it is still what
-        # fieldtags/fielddefaults would answer for this style: if a per-style
-        # or more specific overload exists (possibly stateful), ignore the
-        # registration and consult the live methods every time
+        # The registered data is used only while it matches what the live
+        # fieldtags/fielddefaults methods answer for this style. A per-style
+        # or more specific overload answers differently; the table is then
+        # built from the live methods on every make instead. Compared once
+        # per (type, style) — resolved tables are cached.
         m = meta::RawMeta
-        tm = _whichmeta_style(fieldtags, style, T)
-        dm = _whichmeta_style(fielddefaults, style, T)
-        metaok = m.tagsmethods isa Vector && m.defaultsmethods isa Vector &&
-                 tm in m.tagsmethods && dm in m.defaultsmethods
+        metaok = isequal(_live_tags(style, T), m.tags === nothing ? (;) : m.tags) &&
+                 _defaultsmatch(style, T, m)
     end
     local defaults, tags, thunk
     if metaok
@@ -450,10 +436,10 @@ function valuespec(snap::MetaSnap, style::StructStyle, @nospecialize(ft0), ignor
         # (JIT-only: under juliac the single compile session keeps the
         # registry authoritative)
         !TRIM_BUILD && k == KIND_STRUCT && !structlike(style, ft) && (k = KIND_CUSTOM)
-        # types with their own `make` overloads (e.g. JSON's raw-capture
-        # JSONText) must stay on the generic arm — driving their fields
-        # through the interpreter would silently bypass user semantics
-        !TRIM_BUILD && k == KIND_STRUCT && _has_custom_make(ft) && (k = KIND_CUSTOM)
+        # types that declare their own `make` methods stay on the generic
+        # arm — driving their fields through the interpreter would bypass
+        # those methods
+        !TRIM_BUILD && k == KIND_STRUCT && custommake(ft) && (k = KIND_CUSTOM)
         # style-level trait overrides outrank the structural classification:
         # a struct the style declares dictlike/arraylike belongs to the
         # dispatcher's container arms, not the field-table drive
@@ -555,7 +541,7 @@ function _tagname_aliases(@nospecialize(ftags), fn::Symbol)
 end
 
 # wrapper for a name tag the fast matchers can't turn into strings/symbols
-# ahead of time; _findspec compares these with `keyeq` at match time (JIT
+# ahead of time; findspec compares these with `keyeq` at match time (JIT
 # only)
 struct RawKey
     x::Any
@@ -564,10 +550,13 @@ end
 # `nothing` on throw: a defaults thunk that cannot evaluate standalone
 # (type-parameter-dependent expressions) signals vals-defaults mode, where
 # construction consults the parameterized 3-arg fielddefaults instead
-_callthunk(@nospecialize(f)) = try
-    f()
-catch
-    nothing
+# run a defaults thunk; nothing when it throws (unbound type parameters)
+function _callthunk(@nospecialize(f))
+    try
+        return f()
+    catch
+        return nothing
+    end
 end
 
 # tag helpers on runtime NamedTuples: getfield/haskey on a NamedTuple with a
@@ -587,77 +576,58 @@ end
 _tagbool(@nospecialize(ftags), k::Symbol) =
     ftags isa NamedTuple && haskey(ftags, k) && getfield(ftags, k) === true
 
+# the field name after any `name` tag rename
 function _tagname(@nospecialize(ftags), fn::Symbol)
     ftags isa NamedTuple || return fn
     haskey(ftags, :name) || return fn
     nm = getfield(ftags, :name)
     nm isa Symbol && return nm
     nm isa String && return Symbol(nm)
-    return nothing # exotic name tags (e.g. Tuple aliases) match via _findspec
+    return nothing # exotic name tags (e.g. Tuple aliases) match via findspec
 end
 
+# a field's registered default, or the NODEFAULT sentinel
 function _defaultfor(@nospecialize(defaults), fn::Symbol)
     defaults isa NamedTuple || return NODEFAULT
     haskey(defaults, fn) || return NODEFAULT
     return getfield(defaults, fn)
 end
 
-_live_tags(style::StructStyle, @nospecialize(T)) = try
-    fieldtags(style, T)
-catch
-    (;)
-end
-
-# a `make` method more specific than the generic dispatcher exists for T:
-# checked once per table build (cached with the table; volatile tables are
-# already the deliberate slow path). Queried with the CONCRETE Type{T}
-# singleton — a `Type{<:T}` query would intersect every emitted
-# `make(::StructStyle, ::Type{S}, ::Any) where S<:Other` method through the
-# bottom type (S = Union{} inhabits both bounds)
-_has_custom_make(@nospecialize(T)) = try
-    generic = which(make, Tuple{StructStyle,Type,Any})
-    any(m -> m !== generic, methods(make, Tuple{StructStyle,Type{T},Any}))
-catch
-    false
-end
-
-# Per-type memo of which FIELDS have their own `make` methods, consulted by
-# the hot closures. The lookup happens at first use rather than inside the
-# generated closure code: generated functions expand against the method
-# table as it existed when StructUtils loaded, so they can never see methods
-# a user (or another package) defines later. JIT-only; trim builds never
-# consult it.
-mutable struct _CustomFieldsMemo
-    @atomic table::Dict{Type,Any} # UnionAll targets key here too (#54)
-end
-const _CUSTOM_FIELDS = _CustomFieldsMemo(Dict{Type,Any}())
-const _CUSTOM_FIELDS_LOCK = ReentrantLock()
-
-function _custom_make_fields(::Type{T}) where {T}
-    tbl = @atomic _CUSTOM_FIELDS.table
-    r = get(tbl, T, nothing)
-    r === nothing || return r::NTuple{fieldcount(T),Bool}
-    v = ntuple(i -> _has_custom_make(fieldtype(T, i)), fieldcount(T))
-    lock(_CUSTOM_FIELDS_LOCK)
+# what the live fieldtags methods answer for this style (empty on error)
+function _live_tags(style::StructStyle, @nospecialize(T))
     try
-        old = @atomic _CUSTOM_FIELDS.table
-        if !haskey(old, T)
-            new = copy(old)
-            new[T] = v
-            @atomic _CUSTOM_FIELDS.table = new
-        end
-    finally
-        unlock(_CUSTOM_FIELDS_LOCK)
+        return fieldtags(style, T)
+    catch
+        return (;)
     end
-    return v
 end
 
-_live_pertags(style::StructStyle, @nospecialize(T), fn::Symbol) = try
-    fieldtags(style, T, fn)
-catch
-    (;)
+# whether the live fielddefaults answer for this style still matches the
+# registered defaults (vals-dependent defaults are computed per construct
+# and have nothing stored to compare)
+function _defaultsmatch(style::StructStyle, @nospecialize(T), m::RawMeta)
+    m.valsdependent && return true
+    reg = m.defaults !== nothing ? m.defaults :
+          m.defaultsthunk !== nothing ? (try m.defaultsthunk() catch; nothing end) : (;)
+    reg === nothing && return true # thunk needs bound type parameters
+    live = try
+        fielddefaults(style, T)
+    catch
+        return false
+    end
+    return isequal(live, reg)
 end
 
+# what the live per-field fieldtags method answers (empty on error)
+function _live_pertags(style::StructStyle, @nospecialize(T), fn::Symbol)
+    try
+        return fieldtags(style, T, fn)
+    catch
+        return (;)
+    end
+end
+
+# the cached FieldTable for (T, style), building and caching it on first use
 function fieldtable(@nospecialize(T::Type), style::StructStyle)
     styletype = typeof(style)
     snap = @atomic METASTORE.snap
@@ -692,9 +662,10 @@ end
 
 # ---------------- dispatch-free construction primitives ----------------
 
-_alloc_vector(@nospecialize(E), n::Int) =
+allocvector(@nospecialize(E), n::Int) =
     ccall(:jl_alloc_array_1d, Any, (Any, Csize_t), Core.apply_type(Vector, E), n)
 
+# arr[i] = v through memory builtins, no dispatch on the element type
 function _setvec!(@nospecialize(arr), i::Int, @nospecialize(v))
     ref = getfield(arr, :ref)
     r = Core.memoryrefnew(ref, i, true)
@@ -716,7 +687,7 @@ _kindname(kind::Int8) = 1 <= kind <= length(KINDNAMES) ? KINDNAMES[kind] : "unsu
     throw(ArgumentError(string("tier-0 interpreter cannot produce a ", _kindname(kind),
         " value for field '", name, "'; annotate the struct `:hot` for the specialized path")))
 
-function _construct_interp(style::StructStyle, tbl::FieldTable, slots::Vector{Any}, @nospecialize(source))
+function construct(style::StructStyle, tbl::FieldTable, slots::Vector{Any}, @nospecialize(source))
     tbl.mutable && return _construct_mutable(style, tbl, slots, source)
     specs = tbl.specs
     n = length(specs)
@@ -742,7 +713,7 @@ function _construct_interp(style::StructStyle, tbl::FieldTable, slots::Vector{An
                 _missingfield(sp.name, tbl.T)
             end
         elseif d === FRESHEMPTY
-            slots[i] = _alloc_vector((sp.spec.child::ValueSpec).declft, 0)
+            slots[i] = allocvector((sp.spec.child::ValueSpec).declft, 0)
         elseif d === THUNKDEFAULT
             if TRIM_BUILD
                 _missingfield(sp.name, tbl.T)
@@ -788,7 +759,7 @@ function _construct_mutable(style::StructStyle, tbl::FieldTable, slots::Vector{A
                 sp.spec.nullable ? _setfield!(obj, i, nothing) :
                 sp.spec.missingable ? _setfield!(obj, i, missing) : nothing
             elseif d === FRESHEMPTY
-                _setfield!(obj, i, _alloc_vector((sp.spec.child::ValueSpec).declft, 0))
+                _setfield!(obj, i, allocvector((sp.spec.child::ValueSpec).declft, 0))
             elseif d !== THUNKDEFAULT
                 _setfield!(obj, i, d)
             end
@@ -813,6 +784,7 @@ end
     return (b - UInt8('0')) % Int
 end
 
+# "yyyy-mm-dd" -> Date, errors mentioning the field name
 function _parse_iso_date(s::String, name::String)
     (ncodeunits(s) == 10 && codeunit(s, 5) == UInt8('-') && codeunit(s, 8) == UInt8('-')) ||
         _liftfail(KIND_DATE, name)
@@ -822,6 +794,7 @@ function _parse_iso_date(s::String, name::String)
     return Dates.Date(y, m, d)
 end
 
+# "HH:MM:SS[.sss]" starting at `off` -> (hour, minute, second, millisecond)
 function _parse_iso_timeparts(s::String, off::Int, name::String)
     n = ncodeunits(s)
     (n >= off + 7 && codeunit(s, off + 2) == UInt8(':') && codeunit(s, off + 5) == UInt8(':')) ||
@@ -844,6 +817,7 @@ function _parse_iso_timeparts(s::String, off::Int, name::String)
     return h, mi, sec, ms
 end
 
+# "yyyy-mm-ddTHH:MM:SS[.sss]" -> DateTime, errors mentioning the field name
 function _parse_iso_datetime(s::String, name::String)
     n = ncodeunits(s)
     (n >= 19 && codeunit(s, 5) == UInt8('-') && codeunit(s, 8) == UInt8('-') &&
@@ -864,6 +838,7 @@ end
 # Custom formats still route through the `dateformat` fieldtag.
 lift(::Type{Dates.Date}, x::AbstractString) = _parse_iso_date(String(x), "Date")
 lift(::Type{Dates.DateTime}, x::AbstractString) = _parse_iso_datetime(String(x), "DateTime")
+# default Date/DateTime/Time lifts parse the ISO forms above
 function lift(::Type{Dates.Time}, x::AbstractString)
     h, mi, sec, ms = _parse_iso_timeparts(String(x), 1, "Time")
     return Dates.Time(h, mi, sec, ms)
@@ -871,7 +846,7 @@ end
 
 # lift an already-materialized tree scalar to the spec's exact type; `v` is
 # never `nothing` here (nulls are handled by the caller)
-function _liftleaf(style::StructStyle, kind::Int8, @nospecialize(ft), @nospecialize(v), name::String)
+function liftleaf(style::StructStyle, kind::Int8, @nospecialize(ft), @nospecialize(v), name::String)
     if kind == KIND_STRING
         v isa String && return v
         v isa Symbol && return String(v)
@@ -963,7 +938,9 @@ struct InterpClosure{S<:StructStyle}
     slots::Vector{Any}
 end
 
-function _findspec(specs::Vector{FieldSpec}, @nospecialize(k))
+# index of the field a source key matches (0 when none): position, name,
+# renamed name, then aliases
+function findspec(specs::Vector{FieldSpec}, @nospecialize(k))
     if k isa Int
         # positional sources (Vector/Tuple elements via applyeach): the
         # element index IS the field index
@@ -1008,7 +985,7 @@ end
 
 function (f::InterpClosure{S})(@nospecialize(k), @nospecialize(v)) where {S}
     specs = f.tbl.specs
-    i = _findspec(specs, k)
+    i = findspec(specs, k)
     i == 0 && return unknownfield(f.style, f.tbl.T, k, v)
     sp = @inbounds specs[i]
     vs = sp.spec
@@ -1072,7 +1049,7 @@ function _spec_value(style::StructStyle, vs::ValueSpec, @nospecialize(v), name::
             # direct recursion with a closed nested-source ladder: concrete
             # types keep the applyeach drive statically resolvable (formats
             # with their own tree types route their sources at their own
-            # entry, e.g. JSON drives Object roots through `make` directly)
+            # entry — a format's own tree type routes through `make` directly)
             if v isa Dict{String,Any}
                 x, _ = _interp_make(style, vs.ft, v)
                 return x
@@ -1104,7 +1081,7 @@ function _spec_value(style::StructStyle, vs::ValueSpec, @nospecialize(v), name::
         # 2-union: an array-like source picks the array-like member
         arm = (v isa AbstractArray || v isa AbstractSet) ? (vs.child::ValueSpec) :
                                                            (vs.child2::ValueSpec)
-        return _spec_nullwrap(style, arm, v, name)
+        return makevalue(style, arm, v, name)
     elseif k == KIND_TUPLE
         if TRIM_BUILD
             _liftfail(k, name)
@@ -1119,7 +1096,7 @@ function _spec_value(style::StructStyle, vs::ValueSpec, @nospecialize(v), name::
             el = vs.child::ValueSpec
             if v isa AbstractVector || v isa AbstractSet
                 for ev in v
-                    push!(set, _spec_nullwrap(style, el, ev, name))
+                    push!(set, makevalue(style, el, ev, name))
                 end
                 return set
             end
@@ -1145,13 +1122,13 @@ function _spec_value(style::StructStyle, vs::ValueSpec, @nospecialize(v), name::
             return x
         end
     else
-        return _liftleaf(style, k, vs.ft, v, name)
+        return liftleaf(style, k, vs.ft, v, name)
     end
 end
 
 # nested positions can themselves be nullable (e.g. Vector{Union{T,Nothing}}
 # elements, union arms)
-function _spec_nullwrap(style::StructStyle, vs::ValueSpec, @nospecialize(v), name::String)
+function makevalue(style::StructStyle, vs::ValueSpec, @nospecialize(v), name::String)
     if v === nothing && vs.kind != KIND_ANY && vs.kind != KIND_CUSTOM
         # null-like values fill the Missing arm first when both are admitted
         # (the same order @_peel resolves unions); two branches so each lift
@@ -1171,23 +1148,24 @@ function _spec_nullwrap(style::StructStyle, vs::ValueSpec, @nospecialize(v), nam
     return _spec_value(style, vs, v, name)
 end
 
+# vector-typed positions: allocate the element vector and fill per element
 function _spec_vector(style::StructStyle, vs::ValueSpec, @nospecialize(v), name::String)
     el = vs.child::ValueSpec
     if v isa Vector{Any}
         n = length(v)
-        arr = _alloc_vector(el.declft, n)
+        arr = allocvector(el.declft, n)
         for j = 1:n
-            _setvec!(arr, j, _spec_nullwrap(style, el, @inbounds(v[j]), name))
+            _setvec!(arr, j, makevalue(style, el, @inbounds(v[j]), name))
         end
         return arr
     elseif !TRIM_BUILD && v isa AbstractVector && !(v isa AbstractVector{<:Pair})
         # generic source vectors (e.g. a Vector{Int} value inside a user Dict);
         # pair-element vectors are keyed sources and fall to makearray below
         n = length(v)
-        arr = _alloc_vector(el.declft, n)
+        arr = allocvector(el.declft, n)
         j = 1
         for ev in v
-            _setvec!(arr, j, _spec_nullwrap(style, el, ev, name))
+            _setvec!(arr, j, makevalue(style, el, ev, name))
             j += 1
         end
         return arr
@@ -1212,11 +1190,11 @@ function _spec_dict(style::StructStyle, vs::ValueSpec, @nospecialize(v), name::S
     dict = initialize(style, vs.ft, v)
     if v isa AbstractDict
         for (dk, dv) in v
-            addkeyval!(dict, _liftdictkey(style, vs, dk, name), _spec_nullwrap(style, el, dv, name))
+            addkeyval!(dict, _liftdictkey(style, vs, dk, name), makevalue(style, el, dv, name))
         end
     elseif v isa AbstractVector{<:Pair}
         for (dk, dv) in v
-            addkeyval!(dict, _liftdictkey(style, vs, dk, name), _spec_nullwrap(style, el, dv, name))
+            addkeyval!(dict, _liftdictkey(style, vs, dk, name), makevalue(style, el, dv, name))
         end
     else
         TRIM_BUILD && _liftfail(vs.kind, name)
@@ -1239,7 +1217,7 @@ function _spec_tuple(style::StructStyle, vs::ValueSpec, @nospecialize(v), name::
         for (_, ev) in v
             i >= n && break
             i += 1
-            slots[i] = _spec_nullwrap(style, @inbounds(members[i]), ev, name)
+            slots[i] = makevalue(style, @inbounds(members[i]), ev, name)
         end
     elseif (v isa AbstractVector && !(v isa AbstractVector{<:Pair})) || v isa Tuple
         k = 0
@@ -1252,7 +1230,7 @@ function _spec_tuple(style::StructStyle, vs::ValueSpec, @nospecialize(v), name::
                 continue
             end
             i += 1
-            slots[i] = _spec_nullwrap(style, @inbounds(members[i]), ev, name)
+            slots[i] = makevalue(style, @inbounds(members[i]), ev, name)
         end
     else
         # exotic source: the retained container machinery owns it (calling
@@ -1287,13 +1265,14 @@ function _spec_fixedarray(style::StructStyle, vs::ValueSpec, @nospecialize(v), n
     el = vs.child::ValueSpec
     data = Vector{Any}()
     _flatten_colmajor!(data, v, length(dims))
-    lifted = _alloc_vector(el.declft, length(data))
+    lifted = allocvector(el.declft, length(data))
     for j = 1:length(data)
-        _setvec!(lifted, j, _spec_nullwrap(style, el, @inbounds(data[j]), name))
+        _setvec!(lifted, j, makevalue(style, el, @inbounds(data[j]), name))
     end
     return arrayfromdata(vs.ft, lifted, Tuple(dims))
 end
 
+# append nested source vectors depth-first (column-major element order)
 function _flatten_colmajor!(data::Vector{Any}, @nospecialize(v), depth::Int)
     if depth <= 0 || !(v isa AbstractVector)
         push!(data, v)
@@ -1305,6 +1284,7 @@ function _flatten_colmajor!(data::Vector{Any}, @nospecialize(v), depth::Int)
     return nothing
 end
 
+# convert a source dict key to the declared key type
 function _liftdictkey(style::StructStyle, vs::ValueSpec, @nospecialize(dk), name::String)
     kk = vs.keykind
     if kk == KIND_STRING
@@ -1315,7 +1295,7 @@ function _liftdictkey(style::StructStyle, vs::ValueSpec, @nospecialize(dk), name
         dk isa String && return Symbol(dk)
     elseif dk isa String && (kk == KIND_INT64 || kk == KIND_INT32 || kk == KIND_INT16 ||
            kk == KIND_UINT64 || kk == KIND_UINT32 || kk == KIND_UINT16 || kk == KIND_UINT8)
-        return _liftleaf(style, kk, _dict_keytype(vs.ft), Base.parse(Int64, dk), name)
+        return liftleaf(style, kk, _dict_keytype(vs.ft), Base.parse(Int64, dk), name)
     end
     # odd pairings: the style's liftkey hook decides (JIT)
     return liftkey(style, _dict_keytype(vs.ft), dk)
@@ -1329,7 +1309,7 @@ end
 
 `true` (the default) when `source` may be driven through the tier-0
 interpreter. Formats with lazy source types that carry their own `lift`
-protocols (e.g. JSON's `LazyValue`) overload this to `false`, keeping those
+protocols (a format's lazy value type, say) overload this to `false`, keeping those
 sources on their format-owned descent.
 """
 interpsource(@nospecialize(source)) = true
@@ -1377,7 +1357,7 @@ Base.@nospecializeinfer function _interp_make(style::StructStyle, tbl::FieldTabl
     end
     # EarlyReturn from a custom unknownfield flows through
     # as state; construction still happens
-    return _construct_interp(style, tbl, slots, source), st
+    return construct(style, tbl, slots, source), st
 end
 
 # root ValueSpec for a non-struct target (Vector, Dict, Set, Tuple, Matrix,
@@ -1423,7 +1403,7 @@ Base.@nospecializeinfer function _interp_root(style::StructStyle, @nospecialize(
         # arms own it
         return nothing
     end
-    return _spec_nullwrap(style, vs, source, "root"), defaultstate(style)
+    return makevalue(style, vs, source, "root"), defaultstate(style)
 end
 
 # gate consulted from `make`'s structlike arm under JIT: returns the built

--- a/src/interp.jl
+++ b/src/interp.jl
@@ -1,0 +1,838 @@
+# Tier-0 "interpreter" make path: a non-specializing, field-table-driven
+# construction engine for struct targets from tree-like sources (AbstractDict,
+# Vector{<:Pair}). One compiled instance per (style, source-type) — never per
+# target type — so first-use compile cost for a new struct type is table-build
+# only (microseconds), and the whole engine precompiles into pkgimages.
+#
+# Construction goes through dispatch-free runtime primitives (the same kernel
+# Serialization uses): jl_new_structv from boxed slots, jl_alloc_array_1d +
+# memoryref builtins for typed vectors. All per-field behavior is driven by a
+# closed set of kind tags computed once per type into a FieldTable.
+#
+# Trim story: with the `trim_build` compile-time preference set, the JIT-only
+# arms (per-type fielddefaults/fieldtags consultation, dynamic `lift` for
+# custom leaf types, defaults-thunk re-evaluation, exotic key/source shapes)
+# are compile-time pruned, leaving a graph `juliac --trim=safe` can fully
+# verify. Types registered via the struct macros (or an explicit
+# `register_fieldtable!`) carry their defaults/tags as plain data and parse
+# through the interpreter in trimmed binaries with no per-type dispatch.
+
+# closed kind universe; anything else is KIND_CUSTOM (dynamic lift, JIT-only)
+const KIND_UNSUPPORTED = Int8(0)
+const KIND_STRING = Int8(1)
+const KIND_INT64 = Int8(2)
+const KIND_INT32 = Int8(3)
+const KIND_INT16 = Int8(4)
+const KIND_INT8 = Int8(5)
+const KIND_INT128 = Int8(6)
+const KIND_UINT64 = Int8(7)
+const KIND_UINT32 = Int8(8)
+const KIND_UINT16 = Int8(9)
+const KIND_UINT8 = Int8(10)
+const KIND_UINT128 = Int8(11)
+const KIND_FLOAT64 = Int8(12)
+const KIND_FLOAT32 = Int8(13)
+const KIND_FLOAT16 = Int8(14)
+const KIND_BOOL = Int8(15)
+const KIND_DATE = Int8(16)
+const KIND_DATETIME = Int8(17)
+const KIND_TIME = Int8(18)
+const KIND_UUID = Int8(19)
+const KIND_SYMBOL = Int8(20)
+const KIND_CHAR = Int8(21)
+const KIND_ANY = Int8(22)
+const KIND_STRUCT = Int8(23)
+const KIND_VECTOR = Int8(24)
+const KIND_CUSTOM = Int8(25)
+
+function scalarkind(@nospecialize(ft))
+    ft === String && return KIND_STRING
+    ft === Int64 && return KIND_INT64
+    ft === Int32 && return KIND_INT32
+    ft === Int16 && return KIND_INT16
+    ft === Int8 && return KIND_INT8
+    ft === Int128 && return KIND_INT128
+    ft === UInt64 && return KIND_UINT64
+    ft === UInt32 && return KIND_UINT32
+    ft === UInt16 && return KIND_UINT16
+    ft === UInt8 && return KIND_UINT8
+    ft === UInt128 && return KIND_UINT128
+    ft === Float64 && return KIND_FLOAT64
+    ft === Float32 && return KIND_FLOAT32
+    ft === Float16 && return KIND_FLOAT16
+    ft === Bool && return KIND_BOOL
+    ft === Dates.Date && return KIND_DATE
+    ft === Dates.DateTime && return KIND_DATETIME
+    ft === Dates.Time && return KIND_TIME
+    ft === UUID && return KIND_UUID
+    ft === Symbol && return KIND_SYMBOL
+    ft === Char && return KIND_CHAR
+    ft === Any && return KIND_ANY
+    return KIND_UNSUPPORTED
+end
+
+# sentinel states for the per-field default slot
+struct NoDefault end
+const NODEFAULT = NoDefault()
+struct FreshEmpty end          # empty vector default: re-materialize per construct
+const FRESHEMPTY = FreshEmpty()
+struct ThunkDefault end        # mutable/aliasing-unsafe default: re-eval thunk (JIT only)
+const THUNKDEFAULT = ThunkDefault()
+
+struct FieldSpec
+    name::String       # match name (post fieldtags rename)
+    namesym::Symbol    # same, as Symbol, for Symbol-keyed sources
+    fieldsym::Symbol   # original field name (defaults NamedTuples key on this)
+    kind::Int8
+    nullable::Bool     # Union{..., Nothing}
+    missingable::Bool  # Union{..., Missing}
+    ft::Any            # non-Nothing/Missing field type
+    elkind::Int8       # KIND_VECTOR: element kind
+    elft::Any          # KIND_VECTOR: element type
+    default::Any       # shared boxed default, or NODEFAULT/FRESHEMPTY/THUNKDEFAULT
+end
+
+struct FieldTable
+    T::DataType
+    specs::Vector{FieldSpec}
+    eligible::Bool         # interpreter can construct this type at all
+    anythunk::Bool         # some field needs defaults-thunk re-evaluation (JIT only)
+    defaultsthunk::Any     # () -> NamedTuple, or nothing
+    valsdefaults::Bool     # defaults reference parsed fields: use the 3-arg
+                           # fielddefaults(style, T, vals) semantics (JIT only)
+end
+
+# raw per-type metadata as registered by the struct macros: plain data, so
+# table resolution never needs per-type method dispatch (the trim requirement)
+struct RawMeta
+    defaults::Any        # NamedTuple of defaults evaluated at registration, or nothing
+    defaultsthunk::Any   # () -> NamedTuple for aliasing-unsafe re-evaluation, or nothing
+    tags::Any            # NamedTuple of fieldtags, or nothing
+    nonstruct::Bool      # @nonstruct types lift as leaves, never field-parse
+    tagsmethod::Any      # Method resolving fieldtags at registration time
+    defaultsmethod::Any  # Method resolving fielddefaults at registration time
+    valsdependent::Bool  # defaults reference other (parsed) fields
+end
+
+# registry snapshots are immutable-after-publish; readers take one atomic
+# load and never contend with the write lock (the eligibility gate runs on
+# the hot path of every structlike `make`)
+struct MetaSnap
+    raw::IdDict{Any,RawMeta}
+    # (target type) => [(style type) => resolved table]; per style TYPE
+    # because fieldtagkey namespacing and metadata-method resolution are
+    # style-dependent
+    tables::IdDict{Any,Vector{Pair{DataType,FieldTable}}}
+end
+
+mutable struct MetaStore
+    @atomic snap::MetaSnap
+end
+
+const METASTORE = MetaStore(MetaSnap(IdDict{Any,RawMeta}(),
+    IdDict{Any,Vector{Pair{DataType,FieldTable}}}()))
+const META_LOCK = ReentrantLock()
+
+"""
+    StructUtils.register_fieldtable!(T; defaults=nothing, tags=nothing)
+
+Register tier-0 interpreter metadata for struct type `T`: `defaults` is a
+zero-arg function returning a `NamedTuple` of field defaults (evaluated in
+field order), `tags` a `NamedTuple` of fieldtags. The `@noarg`, `@kwarg`,
+`@defaults`, and `@tags` macros emit a call to this automatically; call it
+manually for types with hand-written `fielddefaults`/`fieldtags` overloads
+that must parse through the interpreter in `juliac --trim` binaries (where
+per-type method consultation is unavailable).
+"""
+function register_fieldtable!(@nospecialize(T::Type); defaults=nothing, tags=nothing,
+                              nonstruct::Bool=false, valsdependent::Bool=false)
+    nt = nothing
+    if defaults !== nothing && !valsdependent
+        # evaluate once, eagerly: the values become plain data usable in
+        # trimmed binaries; parametric defaults that need bound type
+        # parameters may throw here — keep the thunk, resolve per-instantiation
+        nt = try
+            defaults()
+        catch
+            nothing
+        end
+    end
+    # capture which methods resolve this type's metadata right now (the
+    # macro-emitted ones, or the generic fallbacks): if a more specific or
+    # per-style overload appears later, table resolution detects the mismatch
+    # and routes that (style, T) to the classic path instead
+    tm = _whichmeta(fieldtags, T)
+    dm = _whichmeta(fielddefaults, T)
+    # explicit lock/unlock: a `lock() do` closure capturing @nospecialize
+    # arguments is not verifier-resolvable
+    lock(META_LOCK)
+    try
+        old = @atomic METASTORE.snap
+        raw = copy(old.raw)
+        raw[T] = RawMeta(nt, defaults, tags, nonstruct, tm, dm, valsdependent)
+        tables = copy(old.tables)
+        empty!(tables) # invalidate resolved tables (nested kinds may change)
+        @atomic METASTORE.snap = MetaSnap(raw, tables)
+    finally
+        unlock(META_LOCK)
+    end
+    return nothing
+end
+
+_whichmeta(@nospecialize(f), @nospecialize(T)) = try
+    which(f, Tuple{StructStyle, Type{T}})
+catch
+    nothing
+end
+
+_whichmeta_style(@nospecialize(f), @nospecialize(style), @nospecialize(T)) = try
+    which(f, Tuple{typeof(style), Type{T}})
+catch
+    nothing
+end
+
+# ---------------- table resolution ----------------
+
+# builtin-only union peel: strips Nothing/Missing from up to 3-component
+# unions; a wider union or non-concrete remainder ends up KIND_UNSUPPORTED
+function peel_nullmissing(@nospecialize(ft0))
+    nullable = false
+    missingable = false
+    ft = ft0
+    for _ = 1:2
+        ft isa Union || break
+        a = getfield(ft, :a)
+        b = getfield(ft, :b)
+        if a === Nothing
+            nullable = true
+            ft = b
+        elseif b === Nothing
+            nullable = true
+            ft = a
+        elseif a === Missing
+            missingable = true
+            ft = b
+        elseif b === Missing
+            missingable = true
+            ft = a
+        else
+            break
+        end
+    end
+    return nullable, missingable, ft
+end
+
+_isvectortype(@nospecialize(ft)) =
+    ft isa DataType && getfield(getfield(ft, :name), :wrapper) === Array &&
+    length(getfield(ft, :parameters)::Core.SimpleVector) == 2 &&
+    (getfield(ft, :parameters)::Core.SimpleVector)[2] === 1
+
+_vector_eltype(@nospecialize(ft)) = (getfield(ft, :parameters)::Core.SimpleVector)[1]
+
+_vectype(@nospecialize(E)) = Core.apply_type(Vector, E)
+
+function kindfor(@nospecialize(ft))
+    k = scalarkind(ft)
+    k != KIND_UNSUPPORTED && return k
+    ft isa DataType || return KIND_UNSUPPORTED
+    _isvectortype(ft) && return KIND_VECTOR
+    if isstructtype(ft) && !ismutabletype(ft) && !Base.issingletontype(ft) &&
+       isconcretetype(ft) && !(ft <: AbstractDict) && !(ft <: AbstractArray) &&
+       !(ft <: AbstractSet) && !(ft <: AbstractString) && !(ft <: Tuple) &&
+       !(ft <: NamedTuple) && !(ft <: Function)
+        return KIND_STRUCT
+    end
+    return KIND_UNSUPPORTED
+end
+
+# classify one evaluated default value for aliasing safety. FRESHEMPTY only
+# applies to empty Arrays (matching the KIND_VECTOR construct arm); the
+# narrow isa keeps the length call verifier-resolvable
+function classify_default(@nospecialize(v))
+    # size read via the field: generic length on an abstract Array does not
+    # devirtualize for the trim verifier
+    v isa Vector && (getfield(v, :size)::Tuple{Int})[1] == 0 && return FRESHEMPTY
+    (isbits(v) || v isa String || v isa Symbol) && return v
+    return THUNKDEFAULT
+end
+
+_rawmeta(snap::MetaSnap, @nospecialize(T)) = begin
+    m = get(snap.raw, T, nothing)
+    if m === nothing && T isa DataType
+        # parametric structs register under their UnionAll wrapper
+        m = get(snap.raw, getfield(getfield(T, :name), :wrapper), nothing)
+    end
+    m
+end
+
+function buildtable(@nospecialize(T::Type), style::StructStyle)
+    T isa DataType ||
+        return FieldTable(Nothing, FieldSpec[], false, false, nothing, false)
+    tagkey = fieldtagkey(style)
+    snap = @atomic METASTORE.snap
+    meta = _rawmeta(snap, T)
+    metaok = meta !== nothing
+    valsdefaults = metaok && (meta::RawMeta).valsdependent
+    if metaok && !TRIM_BUILD
+        # the registered data is only valid while it is still what
+        # fieldtags/fielddefaults would answer for this style: a per-style or
+        # more specific overload (possibly stateful) routes to the classic
+        # path, preserving exact semantics
+        m = meta::RawMeta
+        metaok = _whichmeta_style(fieldtags, style, T) === m.tagsmethod &&
+                 _whichmeta_style(fielddefaults, style, T) === m.defaultsmethod
+    end
+    local defaults, tags, thunk
+    if metaok
+        m = meta::RawMeta
+        thunk = m.defaultsthunk
+        defaults = valsdefaults ? (;) :
+                   m.defaults !== nothing ? m.defaults :
+                   (!TRIM_BUILD && thunk !== nothing ? _callthunk(thunk) : (;))
+        tags = m.tags === nothing ? (;) : m.tags
+    elseif TRIM_BUILD
+        # trimmed binaries cannot consult per-type fielddefaults/fieldtags
+        # methods (open dynamic dispatch); unregistered types parse with
+        # reflection only (no defaults, no tag renames)
+        defaults = (;)
+        tags = (;)
+        thunk = nothing
+    else
+        # unregistered (or overridden) type under JIT: the classic path owns
+        # it — exact semantics for manual/stateful metadata overloads
+        return FieldTable(T, FieldSpec[], false, false, nothing, false)
+    end
+    names = getfield(getfield(T, :name), :names)::Core.SimpleVector
+    n = fieldcount(T)
+    specs = Vector{FieldSpec}(undef, n)
+    eligible = isstructtype(T) && !ismutabletype(T) && !Base.issingletontype(T) &&
+               isconcretetype(T) && n > 0 && !(T <: Tuple) && !(T <: NamedTuple) &&
+               !(T <: AbstractDict) && !(T <: AbstractArray) && !(T <: AbstractSet) &&
+               !(T <: AbstractString) && !(T <: Function) && !(T <: Type)
+    anythunk = false
+    for i = 1:n
+        fn = names[i]::Symbol
+        ftags = _fieldtag_nt(tags, fn, tagkey)
+        ignored = _tagbool(ftags, :ignore)
+        nm = _tagname(ftags, fn)
+        nm === nothing && (eligible = false; nm = fn)
+        ft0 = fieldtype(T, i)
+        nullable, missingable, ft = peel_nullmissing(ft0)
+        k = ignored ? KIND_UNSUPPORTED : kindfor(ft)
+        if k == KIND_STRUCT
+            fm = _rawmeta(snap, ft)
+            fm !== nothing && (fm::RawMeta).nonstruct && (k = KIND_CUSTOM)
+        end
+        # lift/choosetype/dateformat tags force the dynamic arm
+        if k != KIND_UNSUPPORTED && ftags isa NamedTuple &&
+           (haskey(ftags, :lift) || haskey(ftags, :choosetype) || haskey(ftags, :dateformat))
+            k = KIND_CUSTOM
+        end
+        if k == KIND_UNSUPPORTED && !ignored
+            # a field the interpreter can't produce directly: leaf-ish types
+            # get the dynamic-lift arm; containers/exotics make T ineligible
+            if ft isa DataType && !(ft <: AbstractDict) && !(ft <: AbstractArray) &&
+               !(ft <: AbstractSet) && !(ft <: Tuple) && !(ft <: NamedTuple)
+                k = KIND_CUSTOM
+            else
+                eligible = false
+            end
+        end
+        elk = KIND_UNSUPPORTED
+        elft = nothing
+        if k == KIND_VECTOR
+            elft = _vector_eltype(ft)
+            elk = elft isa Type ? kindfor(elft) : KIND_UNSUPPORTED
+            if elk == KIND_STRUCT
+                em = _rawmeta(snap, elft)
+                em !== nothing && (em::RawMeta).nonstruct && (elk = KIND_CUSTOM)
+            end
+            if elk == KIND_UNSUPPORTED || elk == KIND_VECTOR || elk == KIND_CUSTOM
+                # Vector{exotic}/nested vectors keep today's specialized path;
+                # KIND_CUSTOM elements stay old-path too so per-element lift
+                # tags/choosetype semantics are byte-identical
+                eligible = false
+            end
+        end
+        rawdef = _defaultfor(defaults, fn)
+        def = rawdef isa NoDefault ? NODEFAULT : classify_default(rawdef)
+        if def === THUNKDEFAULT
+            anythunk = true
+        elseif !(rawdef isa NoDefault) && def !== FRESHEMPTY
+            def = rawdef
+        end
+        specs[i] = FieldSpec(String(nm), nm, fn, k, nullable, missingable, ft, elk, elft, def)
+    end
+    if anythunk
+        thunk === nothing && (eligible = false)
+    end
+    valsdefaults && TRIM_BUILD && (eligible = false)
+    return FieldTable(T, specs, eligible, anythunk && !valsdefaults,
+        (anythunk && !valsdefaults) ? thunk : nothing, valsdefaults)
+end
+
+_callthunk(@nospecialize(f)) = try
+    f()
+catch
+    (;)
+end
+
+# tag helpers on runtime NamedTuples: getfield/haskey on a NamedTuple with a
+# runtime Symbol are builtin-backed, no dispatch
+function _fieldtag_nt(@nospecialize(tags), fn::Symbol, tagkey::Union{Nothing,Symbol})
+    tags isa NamedTuple || return nothing
+    haskey(tags, fn) || return nothing
+    ft = getfield(tags, fn)
+    ft isa NamedTuple || return nothing
+    if tagkey !== nothing && haskey(ft, tagkey)
+        sub = getfield(ft, tagkey)
+        sub isa NamedTuple && return sub
+    end
+    return ft
+end
+
+_tagbool(@nospecialize(ftags), k::Symbol) =
+    ftags isa NamedTuple && haskey(ftags, k) && getfield(ftags, k) === true
+
+function _tagname(@nospecialize(ftags), fn::Symbol)
+    ftags isa NamedTuple || return fn
+    haskey(ftags, :name) || return fn
+    nm = getfield(ftags, :name)
+    nm isa Symbol && return nm
+    nm isa String && return Symbol(nm)
+    return nothing # exotic name tags (e.g. Tuple aliases) keep the classic path
+end
+
+function _defaultfor(@nospecialize(defaults), fn::Symbol)
+    defaults isa NamedTuple || return NODEFAULT
+    haskey(defaults, fn) || return NODEFAULT
+    return getfield(defaults, fn)
+end
+
+function fieldtable(@nospecialize(T::Type), style::StructStyle)
+    styletype = typeof(style)
+    snap = @atomic METASTORE.snap
+    entry = get(snap.tables, T, nothing)
+    if entry !== nothing
+        for (st, tbl) in entry
+            st === styletype && return tbl
+        end
+    end
+    tbl = buildtable(T, style)
+    lock(META_LOCK)
+    try
+        old = @atomic METASTORE.snap
+        tables = copy(old.tables)
+        v = get(tables, T, nothing)
+        v = v === nothing ? Vector{Pair{DataType,FieldTable}}() : copy(v)
+        found = false
+        for (st, _) in v
+            st === styletype && (found = true; break)
+        end
+        if !found
+            push!(v, styletype => tbl)
+            tables[T] = v
+            @atomic METASTORE.snap = MetaSnap(old.raw, tables)
+        end
+    finally
+        unlock(META_LOCK)
+    end
+    return tbl
+end
+
+# ---------------- dispatch-free construction primitives ----------------
+
+_alloc_vector(@nospecialize(E), n::Int) =
+    ccall(:jl_alloc_array_1d, Any, (Any, Csize_t), Core.apply_type(Vector, E), n)
+
+function _setvec!(@nospecialize(arr), i::Int, @nospecialize(v))
+    ref = getfield(arr, :ref)
+    r = Core.memoryrefnew(ref, i, true)
+    Core.memoryrefset!(r, v, :not_atomic, false)
+    return nothing
+end
+
+@noinline _missingfield(name::String, T::DataType) =
+    throw(ArgumentError(string("missing required field '", name, "' constructing ", String(nameof(T)))))
+
+@noinline _liftfail(kind::Int8, name::String) =
+    throw(ArgumentError(string("tier-0 interpreter cannot lift value for field '", name,
+        "' (kind ", Int(kind), "); define the struct with `:hot` or register a supported kind")))
+
+function _construct_interp(style::StructStyle, tbl::FieldTable, slots::Vector{Any})
+    specs = tbl.specs
+    n = length(specs)
+    defs = if !TRIM_BUILD && tbl.valsdefaults
+        # defaults referencing parsed fields: evaluate against the slots,
+        # exactly like the classic _construct slow path
+        fielddefaults(style, tbl.T, slots)
+    elseif !TRIM_BUILD && tbl.anythunk
+        _callthunk(tbl.defaultsthunk)
+    else
+        nothing
+    end
+    for i = 1:n
+        isassigned(slots, i) && continue
+        sp = @inbounds specs[i]
+        d = tbl.valsdefaults ? THUNKDEFAULT : sp.default
+        if d === NODEFAULT
+            if sp.nullable
+                slots[i] = nothing
+            elseif sp.missingable
+                slots[i] = missing
+            else
+                _missingfield(sp.name, tbl.T)
+            end
+        elseif d === FRESHEMPTY
+            slots[i] = _alloc_vector(sp.elft, 0)
+        elseif d === THUNKDEFAULT
+            if TRIM_BUILD
+                _missingfield(sp.name, tbl.T)
+            else
+                d2 = _defaultfor(defs, sp.fieldsym)
+                if d2 isa NoDefault
+                    if sp.nullable
+                        slots[i] = nothing
+                    elseif sp.missingable
+                        slots[i] = missing
+                    else
+                        _missingfield(sp.name, tbl.T)
+                    end
+                else
+                    slots[i] = d2
+                end
+            end
+        else
+            slots[i] = d
+        end
+    end
+    GC.@preserve slots begin
+        return ccall(:jl_new_structv, Any, (Any, Ptr{Any}, UInt32), tbl.T, pointer(slots), n % UInt32)
+    end
+end
+
+# ---------------- leaf lifting (closed kinds; exact-typed results) ----------------
+
+# ISO 8601 fast paths: Dates' DateFormat machinery is both slower and not
+# trim-verifiable in its error paths
+@inline function _dig(cs::String, i::Int, name::String)
+    b = codeunit(cs, i)
+    (UInt8('0') <= b <= UInt8('9')) || _liftfail(KIND_DATE, name)
+    return (b - UInt8('0')) % Int
+end
+
+function _parse_iso_date(s::String, name::String)
+    (ncodeunits(s) == 10 && codeunit(s, 5) == UInt8('-') && codeunit(s, 8) == UInt8('-')) ||
+        _liftfail(KIND_DATE, name)
+    y = _dig(s, 1, name) * 1000 + _dig(s, 2, name) * 100 + _dig(s, 3, name) * 10 + _dig(s, 4, name)
+    m = _dig(s, 6, name) * 10 + _dig(s, 7, name)
+    d = _dig(s, 9, name) * 10 + _dig(s, 10, name)
+    return Dates.Date(y, m, d)
+end
+
+function _parse_iso_timeparts(s::String, off::Int, name::String)
+    n = ncodeunits(s)
+    (n >= off + 7 && codeunit(s, off + 2) == UInt8(':') && codeunit(s, off + 5) == UInt8(':')) ||
+        _liftfail(KIND_TIME, name)
+    h = _dig(s, off, name) * 10 + _dig(s, off + 1, name)
+    mi = _dig(s, off + 3, name) * 10 + _dig(s, off + 4, name)
+    sec = _dig(s, off + 6, name) * 10 + _dig(s, off + 7, name)
+    ms = 0
+    if n >= off + 9 && codeunit(s, off + 8) == UInt8('.')
+        mult = 100
+        i = off + 9
+        while i <= n && mult > 0
+            b = codeunit(s, i)
+            (UInt8('0') <= b <= UInt8('9')) || break
+            ms += ((b - UInt8('0')) % Int) * mult
+            mult = div(mult, 10)
+            i += 1
+        end
+    end
+    return h, mi, sec, ms
+end
+
+function _parse_iso_datetime(s::String, name::String)
+    n = ncodeunits(s)
+    (n >= 19 && codeunit(s, 5) == UInt8('-') && codeunit(s, 8) == UInt8('-') &&
+     (codeunit(s, 11) == UInt8('T') || codeunit(s, 11) == UInt8(' '))) ||
+        _liftfail(KIND_DATETIME, name)
+    y = _dig(s, 1, name) * 1000 + _dig(s, 2, name) * 100 + _dig(s, 3, name) * 10 + _dig(s, 4, name)
+    m = _dig(s, 6, name) * 10 + _dig(s, 7, name)
+    d = _dig(s, 9, name) * 10 + _dig(s, 10, name)
+    h, mi, sec, ms = _parse_iso_timeparts(s, 12, name)
+    return Dates.DateTime(y, m, d, h, mi, sec, ms)
+end
+
+# lift an already-materialized tree scalar to the spec's exact type; `v` is
+# never `nothing` here (nulls are handled by the caller)
+function _liftleaf(style::StructStyle, kind::Int8, @nospecialize(ft), @nospecialize(v), name::String)
+    if kind == KIND_STRING
+        v isa String && return v
+        v isa Symbol && return String(v)
+    elseif kind == KIND_INT64
+        v isa Int64 && return v
+        v isa Float64 && return Int64(v)
+    elseif kind == KIND_FLOAT64
+        v isa Float64 && return v
+        v isa Int64 && return Float64(v)
+    elseif kind == KIND_BOOL
+        v isa Bool && return v
+    elseif kind == KIND_DATE
+        v isa Dates.Date && return v
+        v isa String && return _parse_iso_date(v, name)
+    elseif kind == KIND_DATETIME
+        v isa Dates.DateTime && return v
+        v isa String && return _parse_iso_datetime(v, name)
+    elseif kind == KIND_TIME
+        v isa Dates.Time && return v
+        if v isa String
+            h, mi, sec, ms = _parse_iso_timeparts(v, 1, name)
+            return Dates.Time(h, mi, sec, ms)
+        end
+    elseif kind == KIND_UUID
+        v isa UUID && return v
+        v isa String && return UUID(v)
+    elseif kind == KIND_SYMBOL
+        v isa Symbol && return v
+        v isa String && return Symbol(v)
+    elseif kind == KIND_CHAR
+        v isa Char && return v
+        if v isa String
+            length(v) == 1 || _liftfail(kind, name)
+            return v[1]
+        end
+    elseif kind == KIND_INT32
+        v isa Int32 && return v
+        v isa Int64 && return Int32(v)
+        v isa Float64 && return Int32(v)
+    elseif kind == KIND_INT16
+        v isa Int16 && return v
+        v isa Int64 && return Int16(v)
+    elseif kind == KIND_INT8
+        v isa Int8 && return v
+        v isa Int64 && return Int8(v)
+    elseif kind == KIND_INT128
+        v isa Int128 && return v
+        v isa Int64 && return Int128(v)
+    elseif kind == KIND_UINT64
+        v isa UInt64 && return v
+        v isa Int64 && return UInt64(v)
+    elseif kind == KIND_UINT32
+        v isa UInt32 && return v
+        v isa Int64 && return UInt32(v)
+    elseif kind == KIND_UINT16
+        v isa UInt16 && return v
+        v isa Int64 && return UInt16(v)
+    elseif kind == KIND_UINT8
+        v isa UInt8 && return v
+        v isa Int64 && return UInt8(v)
+    elseif kind == KIND_UINT128
+        v isa UInt128 && return v
+        v isa Int64 && return UInt128(v)
+    elseif kind == KIND_FLOAT32
+        v isa Float32 && return v
+        v isa Float64 && return Float32(v)
+        v isa Int64 && return Float32(v)
+    elseif kind == KIND_FLOAT16
+        v isa Float16 && return v
+        v isa Float64 && return Float16(v)
+        v isa Int64 && return Float16(v)
+    end
+    if TRIM_BUILD
+        _liftfail(kind, name)
+    else
+        # JIT fallback: same semantics `make` has always had for leaves
+        x, _ = lift(style, ft, v)
+        return x
+    end
+end
+
+# ---------------- the interpreter ----------------
+
+# per-(style, source) closure; deliberately NOT parameterized on the target
+# type, so applyeach specializes once per source shape, never per struct
+struct InterpClosure{S<:StructStyle}
+    style::S
+    tbl::FieldTable
+    slots::Vector{Any}
+end
+
+function _findspec(specs::Vector{FieldSpec}, @nospecialize(k))
+    if k isa Symbol
+        for i = 1:length(specs)
+            @inbounds(specs[i]).namesym === k && return i
+        end
+    elseif k isa String
+        for i = 1:length(specs)
+            @inbounds(specs[i]).name == k && return i
+        end
+    elseif !TRIM_BUILD
+        # exotic key types (lowerkey overloads): JIT-only generic match
+        for i = 1:length(specs)
+            keyeq(k, @inbounds(specs[i]).name) && return i
+        end
+    end
+    return 0
+end
+
+function (f::InterpClosure{S})(@nospecialize(k), @nospecialize(v)) where {S}
+    specs = f.tbl.specs
+    i = _findspec(specs, k)
+    i == 0 && return unknownfield(f.style, f.tbl.T, k, v)
+    sp = @inbounds specs[i]
+    if v === nothing && sp.kind != KIND_ANY
+        if sp.nullable
+            f.slots[i] = nothing
+        elseif sp.missingable
+            f.slots[i] = missing
+        elseif TRIM_BUILD
+            _liftfail(sp.kind, sp.name)
+        else
+            x, _ = lift(f.style, sp.ft, nothing)
+            f.slots[i] = x
+        end
+        return defaultstate(f.style)
+    end
+    f.slots[i] = _interp_value(f.style, sp, v)
+    return defaultstate(f.style)
+end
+
+function _interp_value(style::StructStyle, sp::FieldSpec, @nospecialize(v))
+    k = sp.kind
+    if k == KIND_STRUCT
+        if TRIM_BUILD
+            # direct recursion with a closed nested-source ladder: concrete
+            # types keep the applyeach drive statically resolvable (formats
+            # with their own tree types route their sources at their own
+            # entry, e.g. JSON drives Object roots through `make` directly)
+            if v isa Dict{String,Any}
+                x, _ = _interp_make(style, sp.ft, v)
+                return x
+            elseif v isa Dict{Symbol,Any}
+                x, _ = _interp_make(style, sp.ft, v)
+                return x
+            else
+                _liftfail(k, sp.name)
+            end
+        else
+            # JIT: route through the dispatcher so per-style trait overloads
+            # (dictlike/arraylike/noarg/structlike) keep exact semantics; it
+            # re-enters the interpreter through the gate when appropriate
+            x, _ = make(style, sp.ft::Type, v)
+            return x
+        end
+    elseif k == KIND_VECTOR
+        return _interp_vector(style, sp, v)
+    elseif k == KIND_ANY
+        return v
+    elseif k == KIND_CUSTOM
+        if TRIM_BUILD
+            _liftfail(k, sp.name)
+        else
+            x, _ = make(style, sp.ft, v)
+            return x
+        end
+    else
+        return _liftleaf(style, k, sp.ft, v, sp.name)
+    end
+end
+
+function _interp_vecel(style::StructStyle, elk::Int8, @nospecialize(elft), @nospecialize(ev), name::String)
+    if elk == KIND_STRUCT
+        if TRIM_BUILD
+            if ev isa Dict{String,Any}
+                x, _ = _interp_make(style, elft, ev)
+                return x
+            elseif ev isa Dict{Symbol,Any}
+                x, _ = _interp_make(style, elft, ev)
+                return x
+            else
+                _liftfail(elk, name)
+            end
+        else
+            x, _ = make(style, elft::Type, ev)
+            return x
+        end
+    elseif elk == KIND_ANY
+        return ev
+    else
+        return _liftleaf(style, elk, elft, ev, name)
+    end
+end
+
+function _interp_vector(style::StructStyle, sp::FieldSpec, @nospecialize(v))
+    elk = sp.elkind
+    elft = sp.elft
+    if v isa Vector{Any}
+        n = length(v)
+        arr = _alloc_vector(elft, n)
+        for j = 1:n
+            _setvec!(arr, j, _interp_vecel(style, elk, elft, @inbounds(v[j]), sp.name))
+        end
+        return arr
+    elseif !TRIM_BUILD && v isa AbstractVector
+        # generic source vectors (e.g. a Vector{Int} value inside a user Dict)
+        n = length(v)
+        arr = _alloc_vector(elft, n)
+        j = 1
+        for ev in v
+            _setvec!(arr, j, _interp_vecel(style, elk, elft, ev, sp.name))
+            j += 1
+        end
+        return arr
+    end
+    if TRIM_BUILD
+        _liftfail(elk, sp.name)
+    else
+        # non-vector source for a vector field: today's generic path decides
+        x, _ = make(style, _vectype(elft), v)
+        return x
+    end
+end
+
+# true when `source` is a tree shape the interpreter drives directly; under
+# trim only AbstractDict (the Vector{Pair} applyeach dispatch is ambiguous
+# between the Pair-vector and AbstractArray methods for the verifier)
+_interpsource(@nospecialize(source)) =
+    TRIM_BUILD ? source isa AbstractDict :
+    (source isa AbstractDict || source isa AbstractVector{<:Pair})
+
+# entry: returns (value, state) like every `make`. Both the target type and
+# the source are inference-erased (one instance per style, ever — the
+# engine's whole point); the drive ladder gives the trim verifier concrete
+# applyeach targets, with a dynamic-dispatch arm for arbitrary tree shapes
+# under JIT (specializing on source here invites invalidation-recompile
+# blowups when extensions load mid-session)
+Base.@nospecializeinfer function _interp_make(style::StructStyle, @nospecialize(T::Type), @nospecialize(source))
+    tbl = fieldtable(T, style)
+    if !tbl.eligible
+        # trim recursion into an ineligible type fails loudly at parse time;
+        # under JIT the dispatcher gate prevents reaching here, but fall back
+        # to the generic path for robustness
+        TRIM_BUILD && _liftfail(KIND_STRUCT, String(nameof(tbl.T)))
+        return make(style, T, source)
+    end
+    slots = Vector{Any}(undef, length(tbl.specs))
+    f = InterpClosure(style, tbl, slots)
+    st = if source isa Dict{String,Any}
+        applyeach(style, f, source)
+    elseif source isa Dict{Symbol,Any}
+        applyeach(style, f, source)
+    elseif !TRIM_BUILD
+        applyeach(style, f, source)
+    else
+        _liftfail(KIND_STRUCT, String(nameof(tbl.T)))
+    end
+    # match makestruct: EarlyReturn from a custom unknownfield flows through
+    # as state; construction still happens
+    return _construct_interp(style, tbl, slots), st
+end
+
+# gate consulted from `make`'s structlike arm: interpret when the target has
+# an eligible table and the source is tree-shaped
+function _interpready(style::StructStyle, @nospecialize(T::Type), @nospecialize(source))
+    T isa DataType || return false
+    _interpsource(source) || return false
+    return fieldtable(T, style).eligible
+end

--- a/src/interp.jl
+++ b/src/interp.jl
@@ -140,7 +140,8 @@ const METASTORE = MetaStore(MetaSnap(IdDict{Any,RawMeta}(),
 const META_LOCK = ReentrantLock()
 
 """
-    StructUtils.register_fieldtable!(T; defaults=nothing, tags=nothing)
+    StructUtils.register_fieldtable!(T; defaults=nothing, tags=nothing,
+                                     nonstruct=false, valsdependent=false)
 
 Register tier-0 interpreter metadata for struct type `T`: `defaults` is a
 zero-arg function returning a `NamedTuple` of field defaults (evaluated in
@@ -469,9 +470,16 @@ end
 @noinline _missingfield(name::String, T::DataType) =
     throw(ArgumentError(string("missing required field '", name, "' constructing ", String(nameof(T)))))
 
+const KINDNAMES = ("String", "Int64", "Int32", "Int16", "Int8", "Int128",
+    "UInt64", "UInt32", "UInt16", "UInt8", "UInt128", "Float64", "Float32",
+    "Float16", "Bool", "Date", "DateTime", "Time", "UUID", "Symbol", "Char",
+    "Any", "struct", "vector", "custom")
+
+_kindname(kind::Int8) = 1 <= kind <= length(KINDNAMES) ? KINDNAMES[kind] : "unsupported"
+
 @noinline _liftfail(kind::Int8, name::String) =
-    throw(ArgumentError(string("tier-0 interpreter cannot lift value for field '", name,
-        "' (kind ", Int(kind), "); define the struct with `:hot` or register a supported kind")))
+    throw(ArgumentError(string("tier-0 interpreter cannot produce a ", _kindname(kind),
+        " value for field '", name, "'; annotate the struct `:hot` for the specialized path")))
 
 function _construct_interp(style::StructStyle, tbl::FieldTable, slots::Vector{Any})
     specs = tbl.specs
@@ -864,4 +872,43 @@ function _interpready(style::StructStyle, @nospecialize(T::Type), @nospecialize(
     T isa DataType || return false
     _interpsource(source) || return false
     return fieldtable(T, style).eligible
+end
+
+"""
+    StructUtils.interpready(style, T) -> Bool
+
+`true` when the tier-0 interpreter has an eligible field table for `T` under
+`style` — i.e. a tree-shaped `make` will construct through the interpreter.
+"""
+interpready(style::StructStyle, @nospecialize(T::Type)) =
+    T isa DataType && fieldtable(T, style).eligible
+
+"""
+    StructUtils.interptreesafe(style, T) -> Bool
+
+`true` when `T`'s field table — including nested struct and vector-element
+tables — contains no choosetype-tagged fields or abstract CUSTOM leaves.
+Those receive the raw source value in user functions, so formats that
+materialize an alternate tree representation for the interpreter (e.g. JSON
+parsing to `Object` instead of handing out lazy values) must keep such types
+on their classic path.
+"""
+interptreesafe(style::StructStyle, @nospecialize(T::Type)) =
+    _treesafe(style, T, Base.IdSet{Any}())
+
+function _treesafe(style::StructStyle, @nospecialize(T), seen::Base.IdSet{Any})::Bool
+    T in seen && return true
+    push!(seen, T)
+    T isa DataType || return true
+    tbl = fieldtable(T, style)
+    tbl.eligible || return true # routed classic anyway
+    tbl.treesafe || return false
+    for sp in tbl.specs
+        if sp.kind == KIND_STRUCT
+            _treesafe(style, sp.ft, seen) || return false
+        elseif sp.kind == KIND_VECTOR && sp.elkind == KIND_STRUCT
+            _treesafe(style, sp.elft, seen) || return false
+        end
+    end
+    return true
 end

--- a/src/interp.jl
+++ b/src/interp.jl
@@ -90,6 +90,8 @@ struct FieldSpec
     elkind::Int8       # KIND_VECTOR: element kind
     elft::Any          # KIND_VECTOR: element type
     default::Any       # shared boxed default, or NODEFAULT/FRESHEMPTY/THUNKDEFAULT
+    tags::Any          # resolved per-field tag NamedTuple (KIND_CUSTOM passes
+                       # it through the 4-arg make: lift/choosetype/dateformat)
 end
 
 struct FieldTable
@@ -100,6 +102,10 @@ struct FieldTable
     defaultsthunk::Any     # () -> NamedTuple, or nothing
     valsdefaults::Bool     # defaults reference parsed fields: use the 3-arg
                            # fielddefaults(style, T, vals) semantics (JIT only)
+    treesafe::Bool         # own fields free of choosetype tags and abstract
+                           # CUSTOM leaves: those hand the *source* to user
+                           # functions, whose representation formats may not
+                           # change (see interptreesafe for the recursive check)
 end
 
 # raw per-type metadata as registered by the struct macros: plain data, so
@@ -267,7 +273,7 @@ end
 
 function buildtable(@nospecialize(T::Type), style::StructStyle)
     T isa DataType ||
-        return FieldTable(Nothing, FieldSpec[], false, false, nothing, false)
+        return FieldTable(Nothing, FieldSpec[], false, false, nothing, false, true)
     tagkey = fieldtagkey(style)
     snap = @atomic METASTORE.snap
     meta = _rawmeta(snap, T)
@@ -300,7 +306,7 @@ function buildtable(@nospecialize(T::Type), style::StructStyle)
     else
         # unregistered (or overridden) type under JIT: the classic path owns
         # it — exact semantics for manual/stateful metadata overloads
-        return FieldTable(T, FieldSpec[], false, false, nothing, false)
+        return FieldTable(T, FieldSpec[], false, false, nothing, false, true)
     end
     names = getfield(getfield(T, :name), :names)::Core.SimpleVector
     n = fieldcount(T)
@@ -310,6 +316,7 @@ function buildtable(@nospecialize(T::Type), style::StructStyle)
                !(T <: AbstractDict) && !(T <: AbstractArray) && !(T <: AbstractSet) &&
                !(T <: AbstractString) && !(T <: Function) && !(T <: Type)
     anythunk = false
+    treesafe = true
     for i = 1:n
         fn = names[i]::Symbol
         ftags = _fieldtag_nt(tags, fn, tagkey)
@@ -326,6 +333,9 @@ function buildtable(@nospecialize(T::Type), style::StructStyle)
         # lift/choosetype/dateformat tags force the dynamic arm
         if k != KIND_UNSUPPORTED && ftags isa NamedTuple &&
            (haskey(ftags, :lift) || haskey(ftags, :choosetype) || haskey(ftags, :dateformat))
+            # a choosetype function receives the raw source value; formats
+            # that swap source representations must keep the classic path
+            haskey(ftags, :choosetype) && (treesafe = false)
             k = KIND_CUSTOM
         end
         if k == KIND_UNSUPPORTED && !ignored
@@ -334,6 +344,9 @@ function buildtable(@nospecialize(T::Type), style::StructStyle)
             if ft isa DataType && !(ft <: AbstractDict) && !(ft <: AbstractArray) &&
                !(ft <: AbstractSet) && !(ft <: Tuple) && !(ft <: NamedTuple)
                 k = KIND_CUSTOM
+                # abstract leaves may resolve via a type-level @choosetype,
+                # which also receives the raw source value
+                isconcretetype(ft) || (treesafe = false)
             else
                 eligible = false
             end
@@ -361,14 +374,15 @@ function buildtable(@nospecialize(T::Type), style::StructStyle)
         elseif !(rawdef isa NoDefault) && def !== FRESHEMPTY
             def = rawdef
         end
-        specs[i] = FieldSpec(String(nm), nm, fn, k, nullable, missingable, ft, elk, elft, def)
+        specs[i] = FieldSpec(String(nm), nm, fn, k, nullable, missingable, ft, elk, elft, def,
+            ftags isa NamedTuple ? ftags : (;))
     end
     if anythunk
         thunk === nothing && (eligible = false)
     end
     valsdefaults && TRIM_BUILD && (eligible = false)
     return FieldTable(T, specs, eligible, anythunk && !valsdefaults,
-        (anythunk && !valsdefaults) ? thunk : nothing, valsdefaults)
+        (anythunk && !valsdefaults) ? thunk : nothing, valsdefaults, treesafe)
 end
 
 _callthunk(@nospecialize(f)) = try
@@ -564,6 +578,19 @@ function _parse_iso_datetime(s::String, name::String)
     return Dates.DateTime(y, m, d, h, mi, sec, ms)
 end
 
+# the default string lifts for the stdlib date types use these hand-rolled
+# parsers everywhere (not just inside the interpreter): the ISO defaults are
+# what `Date(::String)` accepts anyway, they are faster than the DateFormat
+# machinery, and — decisively — DateFormat's error paths are not
+# trim-verifiable, which poisoned every typed date parse under `--trim`.
+# Custom formats still route through the `dateformat` fieldtag.
+lift(::Type{Dates.Date}, x::AbstractString) = _parse_iso_date(String(x), "Date")
+lift(::Type{Dates.DateTime}, x::AbstractString) = _parse_iso_datetime(String(x), "DateTime")
+function lift(::Type{Dates.Time}, x::AbstractString)
+    h, mi, sec, ms = _parse_iso_timeparts(String(x), 1, "Time")
+    return Dates.Time(h, mi, sec, ms)
+end
+
 # lift an already-materialized tree scalar to the spec's exact type; `v` is
 # never `nothing` here (nulls are handled by the caller)
 function _liftleaf(style::StructStyle, kind::Int8, @nospecialize(ft), @nospecialize(v), name::String)
@@ -681,7 +708,7 @@ function (f::InterpClosure{S})(@nospecialize(k), @nospecialize(v)) where {S}
     i = _findspec(specs, k)
     i == 0 && return unknownfield(f.style, f.tbl.T, k, v)
     sp = @inbounds specs[i]
-    if v === nothing && sp.kind != KIND_ANY
+    if v === nothing && sp.kind != KIND_ANY && sp.kind != KIND_CUSTOM
         if sp.nullable
             f.slots[i] = nothing
         elseif sp.missingable
@@ -730,7 +757,9 @@ function _interp_value(style::StructStyle, sp::FieldSpec, @nospecialize(v))
         if TRIM_BUILD
             _liftfail(k, sp.name)
         else
-            x, _ = make(style, sp.ft, v)
+            # the 4-arg make with the field's resolved tags, so lift/
+            # choosetype/dateformat tags keep their classic semantics
+            x, _ = make(style, sp.ft::Type, v, sp.tags)
             return x
         end
     else

--- a/src/interp.jl
+++ b/src/interp.jl
@@ -1,21 +1,25 @@
-# Tier-0 "interpreter" make path: a non-specializing, field-table-driven
-# construction engine for struct targets from tree-like sources (AbstractDict,
-# Vector{<:Pair}). One compiled instance per (style, source-type) — never per
-# target type — so first-use compile cost for a new struct type is table-build
-# only (microseconds), and the whole engine precompiles into pkgimages.
+# The interpreter: the default way `make` builds structs. Instead of
+# compiling code for each target type, it describes each type once as data —
+# a FieldTable of (name, kind tag, default, tags) per field — and one shared
+# engine walks any source against that table. The engine specializes on the
+# style and the source container type, never on the target, so a brand-new
+# struct type costs a table build (microseconds), and the engine itself is
+# already compiled into the package image.
 #
-# Construction goes through dispatch-free runtime primitives (the same kernel
-# Serialization uses): jl_new_structv from boxed slots, jl_alloc_array_1d +
-# memoryref builtins for typed vectors. All per-field behavior is driven by a
-# closed set of kind tags computed once per type into a FieldTable.
+# Values become fields in two steps: a small closed set of "kind" tags
+# (below) says how to convert each leaf — string, the integer widths, dates,
+# UUIDs, nested struct, vector, dict, ... — and construction then goes
+# through the same runtime primitives Serialization uses (jl_new_structv
+# from a slot buffer; array builtins for typed vectors), which involve no
+# dispatch on the target type.
 #
-# Trim story: with the `trim_build` compile-time preference set, the JIT-only
-# arms (per-type fielddefaults/fieldtags consultation, dynamic `lift` for
-# custom leaf types, defaults-thunk re-evaluation, exotic key/source shapes)
-# are compile-time pruned, leaving a graph `juliac --trim=safe` can fully
-# verify. Types registered via the struct macros (or an explicit
-# `register_fieldtable!`) carry their defaults/tags as plain data and parse
-# through the interpreter in trimmed binaries with no per-type dispatch.
+# In a `trim_build = true` build (a `juliac --trim` binary), the arms that
+# need runtime method lookup — consulting per-type fieldtags/fielddefaults
+# methods, the generic `lift` fallback for custom leaf types, re-running
+# default thunks — are compiled out, since a trimmed binary has no JIT to
+# run them. Types registered by the struct macros carry their defaults and
+# tags as plain data, so they parse through the interpreter in trimmed
+# binaries with nothing left to look up.
 
 # closed kind universe; anything else is KIND_CUSTOM (dynamic lift, JIT-only)
 const KIND_UNSUPPORTED = Int8(0)
@@ -193,7 +197,7 @@ function register_fieldtable!(@nospecialize(T::Type); defaults=nothing, tags=not
     # capture which methods resolve this type's metadata right now (the
     # macro-emitted ones, or the generic fallbacks): if a more specific or
     # per-style overload appears later, table resolution detects the mismatch
-    # and routes that (style, T) to the classic path instead
+    # and rebuilds the table from the live methods instead
     tm = _whichmeta(fieldtags, T)
     dm = _whichmeta(fielddefaults, T)
     # explicit lock/unlock: a `lock() do` closure capturing @nospecialize
@@ -270,8 +274,9 @@ function kindfor(@nospecialize(ft))
     k = scalarkind(ft)
     k != KIND_UNSUPPORTED && return k
     if ft isa Union
-        # Nothing/Missing were already peeled: a remaining 2-union is the
-        # classic arraylike-vs-scalar disambiguation shape
+        # Nothing/Missing were already peeled: a remaining 2-union is
+        # decided by source shape (array-like source -> the array-like
+        # member, anything else -> the other member)
         return KIND_UNION2
     end
     ft isa DataType || return KIND_UNSUPPORTED
@@ -327,9 +332,9 @@ function buildtable(@nospecialize(T::Type), style::StructStyle)
     valsdefaults = metaok && (meta::RawMeta).valsdependent
     if metaok && !TRIM_BUILD
         # the registered data is only valid while it is still what
-        # fieldtags/fielddefaults would answer for this style: a per-style or
-        # more specific overload (possibly stateful) routes to the classic
-        # path, preserving exact semantics
+        # fieldtags/fielddefaults would answer for this style: if a per-style
+        # or more specific overload exists (possibly stateful), ignore the
+        # registration and consult the live methods every time
         m = meta::RawMeta
         tm = _whichmeta_style(fieldtags, style, T)
         dm = _whichmeta_style(fielddefaults, style, T)
@@ -424,11 +429,11 @@ function buildtable(@nospecialize(T::Type), style::StructStyle)
         (anythunk && !valsdefaults) ? thunk : nothing, valsdefaults, volatile)
 end
 
-# build the recursive ValueSpec for one declared type. Unknown shapes degrade
-# to KIND_CUSTOM — the generic 4-arg `make` arm with exact classic semantics
-# (one dynamic call per such value, JIT only) — rather than making the whole
-# type ineligible. Trait consultation is JIT-only; trim builds classify from
-# reflection alone.
+# Build the recursive ValueSpec for one declared field type. Shapes the
+# interpreter has no dedicated handling for degrade to KIND_CUSTOM, which
+# hands each such value to the generic 4-arg `make` (one dynamic call per
+# value) rather than making the whole type ineligible. Trait consultation
+# happens only in JIT sessions; trim builds classify from reflection alone.
 function valuespec(snap::MetaSnap, style::StructStyle, @nospecialize(ft0), ignored::Bool,
                    @nospecialize(ftags))
     nullable, missingable, ft = peel_nullmissing(ft0)
@@ -494,10 +499,10 @@ function valuespec(snap::MetaSnap, style::StructStyle, @nospecialize(ft0), ignor
     elseif k == KIND_UNION2
         a = getfield(ft, :a)
         b = getfield(ft, :b)
-        # mirror the classic rule exactly: disambiguation applies only when
-        # exactly ONE member is arraylike (by the trait defaults: arrays and
-        # sets) — two arraylike members are ambiguous and take the generic
-        # arm, which reproduces classic behavior including its errors
+        # source-shape disambiguation only works when exactly ONE member is
+        # array-like (arrays and sets, per the trait defaults) — with two
+        # array-like members the choice would be ambiguous, so the union
+        # degrades to the generic arm (which errors, deliberately)
         arr_a = _shape_arraylike(a)
         arr_b = _shape_arraylike(b)
         if arr_a == arr_b
@@ -549,8 +554,9 @@ function _tagname_aliases(@nospecialize(ftags), fn::Symbol)
     return fn, RawKey(nm) # exotic name tag: generic keyeq match
 end
 
-# wrapper marking a name tag the fast matchers can't table-ize; _findspec
-# falls back to the classic keyeq contract for these (JIT only)
+# wrapper for a name tag the fast matchers can't turn into strings/symbols
+# ahead of time; _findspec compares these with `keyeq` at match time (JIT
+# only)
 struct RawKey
     x::Any
 end
@@ -587,7 +593,7 @@ function _tagname(@nospecialize(ftags), fn::Symbol)
     nm = getfield(ftags, :name)
     nm isa Symbol && return nm
     nm isa String && return Symbol(nm)
-    return nothing # exotic name tags (e.g. Tuple aliases) keep the classic path
+    return nothing # exotic name tags (e.g. Tuple aliases) match via _findspec
 end
 
 function _defaultfor(@nospecialize(defaults), fn::Symbol)
@@ -615,10 +621,12 @@ catch
     false
 end
 
-# per-type memo of which FIELDS carry their own make methods, for the hot
-# closures (computed in the runtime world at first use, so hooks defined any
-# time before a type's first parse are honored — a generated function's
-# frozen world cannot see them). JIT-only: trim builds never consult it.
+# Per-type memo of which FIELDS have their own `make` methods, consulted by
+# the hot closures. The lookup happens at first use rather than inside the
+# generated closure code: generated functions expand against the method
+# table as it existed when StructUtils loaded, so they can never see methods
+# a user (or another package) defines later. JIT-only; trim builds never
+# consult it.
 mutable struct _CustomFieldsMemo
     @atomic table::Dict{Type,Any} # UnionAll targets key here too (#54)
 end
@@ -713,8 +721,8 @@ function _construct_interp(style::StructStyle, tbl::FieldTable, slots::Vector{An
     specs = tbl.specs
     n = length(specs)
     defs = if !TRIM_BUILD && tbl.valsdefaults
-        # defaults referencing parsed fields (or bound type parameters):
-        # evaluate against the slots, exactly like the classic slow path
+        # defaults that reference other parsed fields (or bound type
+        # parameters) can only be computed now, against the filled slots
         fielddefaults(style, tbl.T, slots)
     elseif !TRIM_BUILD && tbl.anythunk
         _callthunk(tbl.defaultsthunk)
@@ -957,8 +965,8 @@ end
 
 function _findspec(specs::Vector{FieldSpec}, @nospecialize(k))
     if k isa Int
-        # positional sources (Vector/Tuple elements via applyeach): index is
-        # field order, matching the classic closures' `k == i` arm
+        # positional sources (Vector/Tuple elements via applyeach): the
+        # element index IS the field index
         return 1 <= k <= length(specs) ? k : 0
     elseif k isa Symbol
         for i = 1:length(specs)
@@ -1005,8 +1013,8 @@ function (f::InterpClosure{S})(@nospecialize(k), @nospecialize(v)) where {S}
     sp = @inbounds specs[i]
     vs = sp.spec
     if v === nothing && vs.kind != KIND_ANY && vs.kind != KIND_CUSTOM
-        # classic @_peel order: null-like sources take the Missing arm
-        # first when the field admits both
+        # a null-like source value fills a field that admits both Missing
+        # and Nothing with `missing` (same order @_peel resolves unions)
         if vs.missingable
             f.slots[i] = missing
         elseif vs.nullable
@@ -1019,9 +1027,10 @@ function (f::InterpClosure{S})(@nospecialize(k), @nospecialize(v)) where {S}
         end
         return defaultstate(f.style)
     elseif v === missing && vs.kind != KIND_ANY && vs.kind != KIND_CUSTOM
-        # classic @_peel parity: missing is null-like, Missing arm first.
-        # Kept as a separate branch with a CONSTANT third argument so the
-        # lift dispatch narrows to a single method under the verifier.
+        # `missing` fills the Missing arm first, like `nothing` above.
+        # Kept as its own branch so each lift call below has a constant
+        # third argument — a Union-typed argument would make the lift
+        # dispatch ambiguous in trimmed binaries.
         if vs.missingable
             f.slots[i] = missing
         elseif vs.nullable
@@ -1047,7 +1056,7 @@ function _interp_value(style::StructStyle, sp::FieldSpec, @nospecialize(v))
             _liftfail(vs.kind, sp.name)
         else
             # the 4-arg make with the field's resolved tags, so lift/
-            # choosetype/dateformat tags keep their classic semantics
+            # choosetype/dateformat tags behave exactly as documented
             x, _ = make(style, vs.declft::Type, v, sp.tags)
             return x
         end
@@ -1092,7 +1101,7 @@ function _spec_value(style::StructStyle, vs::ValueSpec, @nospecialize(v), name::
             return _spec_dict(style, vs, v, name)
         end
     elseif k == KIND_UNION2
-        # the classic arraylike-vs-scalar two-union rule, by source shape
+        # 2-union: an array-like source picks the array-like member
         arm = (v isa AbstractArray || v isa AbstractSet) ? (vs.child::ValueSpec) :
                                                            (vs.child2::ValueSpec)
         return _spec_nullwrap(style, arm, v, name)
@@ -1130,8 +1139,8 @@ function _spec_value(style::StructStyle, vs::ValueSpec, @nospecialize(v), name::
         if TRIM_BUILD
             _liftfail(k, name)
         else
-            # element/value-position generic arm: classic containers recurse
-            # through the tagless 3-arg make
+            # element/value position: hand the value to the tagless
+            # 3-arg make
             x, _ = make(style, vs.declft::Type, v)
             return x
         end
@@ -1144,14 +1153,15 @@ end
 # elements, union arms)
 function _spec_nullwrap(style::StructStyle, vs::ValueSpec, @nospecialize(v), name::String)
     if v === nothing && vs.kind != KIND_ANY && vs.kind != KIND_CUSTOM
-        # classic @_peel order: Missing arm first when both are admitted
+        # null-like values fill the Missing arm first when both are admitted
+        # (the same order @_peel resolves unions); two branches so each lift
+        # call has a constant third argument (see the closure above)
         vs.missingable && return missing
         vs.nullable && return nothing
         TRIM_BUILD && _liftfail(vs.kind, name)
         x, _ = lift(style, vs.ft, nothing)
         return x
     elseif v === missing && vs.kind != KIND_ANY && vs.kind != KIND_CUSTOM
-        # classic @_peel: missing is null-like, the Missing arm wins first
         vs.missingable && return missing
         vs.nullable && return nothing
         TRIM_BUILD && _liftfail(vs.kind, name)
@@ -1216,10 +1226,10 @@ function _spec_dict(style::StructStyle, vs::ValueSpec, @nospecialize(v), name::S
     return dict
 end
 
-# tuple targets: positional consumption — array sources by index, keyed/
-# iterable sources in encounter order (classic maketuple semantics); members
-# lift through their own specs, construction via the same boxed-slot ccall
-# (tuple types are struct-shaped for jl_new_structv)
+# tuple targets: positional fill — array sources by index, keyed/iterable
+# sources in encounter order; members lift through their own specs, and
+# construction uses the same boxed-slot ccall as structs (tuple types are
+# struct-shaped for jl_new_structv)
 function _spec_tuple(style::StructStyle, vs::ValueSpec, @nospecialize(v), name::String)
     members = vs.child::Vector{ValueSpec}
     n = length(members)
@@ -1236,8 +1246,8 @@ function _spec_tuple(style::StructStyle, vs::ValueSpec, @nospecialize(v), name::
         for ev in v
             k += 1
             if i >= n
-                # surplus positional elements: the style's hook decides
-                # (default ignores, matching the classic tuple closure)
+                # surplus positional elements go to the style's unknownfield
+                # hook (which ignores them by default)
                 unknownfield(style, vs.ft::DataType, k, ev)
                 continue
             end
@@ -1339,22 +1349,14 @@ _interpsource(@nospecialize(source)) =
 # under JIT (specializing on source here invites invalidation-recompile
 # blowups when extensions load mid-session)
 Base.@nospecializeinfer function _interp_make(style::StructStyle, @nospecialize(T::Type), @nospecialize(source))
-    if !(T isa DataType)
-        # incomplete parametric targets can't table; the specialized descent
-        # keeps generic semantics — NOT `make`: the make/_interp_make
-        # inference cycle sends constprop into a never-terminating compile.
-        # The assert keeps _interp_make's return type a Tuple so concrete
-        # call-site destructures stay statically resolvable (trim fails
-        # loudly at parse time).
+    # Targets the interpreter can't table — incomplete parametric types,
+    # mutables without an @noarg registration, defaults it can't re-evaluate
+    # — take the per-type hot path instead (calling back into `make` here
+    # would loop). The Tuple assert keeps this function's return type
+    # concrete enough for callers to destructure statically. Trim builds
+    # fail loudly: the hot path with a runtime-only type isn't compiled.
+    if !(T isa DataType && (tbl = fieldtable(T, style)).eligible)
         TRIM_BUILD && _liftfail(KIND_STRUCT, string(T))
-        return _hot_make3(style, T, source)::Tuple{Any,Any}
-    end
-    tbl = fieldtable(T, style)
-    if !tbl.eligible
-        # tables the interpreter can't drive (mutables without @noarg
-        # registration, thunked defaults with no thunk): the specialized
-        # descent owns them, same shape as the non-DataType arm above
-        TRIM_BUILD && _liftfail(KIND_STRUCT, String(nameof(tbl.T)))
         return _hot_make3(style, T, source)::Tuple{Any,Any}
     end
     return _interp_make(style, tbl, source)
@@ -1406,11 +1408,11 @@ function rootspec(@nospecialize(T::Type), style::StructStyle)
 end
 
 # entry for non-struct targets: run the spec tree over the source and wrap
-# in the (value, state) contract. @nospecializeinfer: the source-trait check
-# must stay a runtime verdict — folding `interpsource(::SomeLazy) = false`
-# at a dispatcher call site erases this arm and invites a pathological
-# constprop spiral through the mutually recursive make family (observed as
-# a never-terminating typed-parse compile in JSON's workload)
+# in the (value, state) contract. The un-specialized arguments keep the
+# source check below a runtime decision: if the compiler could prove its
+# answer at a call site it would delete this arm, and compiling the
+# mutually recursive make functions with arms deleted has hung the
+# compiler outright
 Base.@nospecializeinfer function _interp_root(style::StructStyle, @nospecialize(T::Type), @nospecialize(source))
     # lazy/positional format sources carry their own (value, pos) state
     # contract: the retained container machinery owns them

--- a/src/interp.jl
+++ b/src/interp.jl
@@ -44,6 +44,9 @@ const KIND_ANY = Int8(22)
 const KIND_STRUCT = Int8(23)
 const KIND_VECTOR = Int8(24)
 const KIND_CUSTOM = Int8(25)
+const KIND_DICT = Int8(26)
+const KIND_SET = Int8(27)
+const KIND_UNION2 = Int8(28)
 
 function scalarkind(@nospecialize(ft))
     ft === String && return KIND_STRING
@@ -79,16 +82,28 @@ const FRESHEMPTY = FreshEmpty()
 struct ThunkDefault end        # mutable/aliasing-unsafe default: re-eval thunk (JIT only)
 const THUNKDEFAULT = ThunkDefault()
 
+# recursive description of what to produce at one JSON value position:
+# vector elements, dict values, and two-component-union arms nest as child
+# specs, so arbitrarily nested containers stay table-driven
+struct ValueSpec
+    kind::Int8
+    nullable::Bool     # Union{..., Nothing} at this position
+    missingable::Bool  # Union{..., Missing} at this position
+    declft::Any        # declared (pre-peel) type: allocation type for containers
+    ft::Any            # peeled target type at this position
+    keykind::Int8      # KIND_DICT: key kind (String/Symbol/int widths)
+    child::Any         # ::Union{Nothing,ValueSpec}: vector/set element, dict value,
+                       # or the arraylike arm of a two-component union
+    child2::Any        # ::Union{Nothing,ValueSpec}: the non-arraylike union arm
+end
+
 struct FieldSpec
     name::String       # match name (post fieldtags rename)
     namesym::Symbol    # same, as Symbol, for Symbol-keyed sources
     fieldsym::Symbol   # original field name (defaults NamedTuples key on this)
-    kind::Int8
-    nullable::Bool     # Union{..., Nothing}
-    missingable::Bool  # Union{..., Missing}
-    ft::Any            # non-Nothing/Missing field type
-    elkind::Int8       # KIND_VECTOR: element kind
-    elft::Any          # KIND_VECTOR: element type
+    aliases::Any       # nothing, or (Vector{String}, Vector{Symbol}) extra
+                       # match names from tuple-alias name tags
+    spec::ValueSpec
     default::Any       # shared boxed default, or NODEFAULT/FRESHEMPTY/THUNKDEFAULT
     tags::Any          # resolved per-field tag NamedTuple (KIND_CUSTOM passes
                        # it through the 4-arg make: lift/choosetype/dateformat)
@@ -96,6 +111,7 @@ end
 
 struct FieldTable
     T::DataType
+    mutable::Bool          # @noarg target: construct T() / uninit + setfield!
     specs::Vector{FieldSpec}
     eligible::Bool         # interpreter can construct this type at all
     anythunk::Bool         # some field needs defaults-thunk re-evaluation (JIT only)
@@ -115,8 +131,10 @@ struct RawMeta
     defaultsthunk::Any   # () -> NamedTuple for aliasing-unsafe re-evaluation, or nothing
     tags::Any            # NamedTuple of fieldtags, or nothing
     nonstruct::Bool      # @nonstruct types lift as leaves, never field-parse
-    tagsmethod::Any      # Method resolving fieldtags at registration time
-    defaultsmethod::Any  # Method resolving fielddefaults at registration time
+    tagsmethods::Any     # Methods applicable to fieldtags(::StructStyle, ::Type{<:T})
+                         # at registration (the macro's emissions, incl.
+                         # parameterized forms, or the generic fallback)
+    defaultsmethods::Any # same, for fielddefaults
     valsdependent::Bool  # defaults reference other (parsed) fields
 end
 
@@ -187,7 +205,7 @@ function register_fieldtable!(@nospecialize(T::Type); defaults=nothing, tags=not
 end
 
 _whichmeta(@nospecialize(f), @nospecialize(T)) = try
-    which(f, Tuple{StructStyle, Type{T}})
+    collect(methods(f, Tuple{StructStyle, Type{<:T}}))
 catch
     nothing
 end
@@ -241,12 +259,22 @@ _vectype(@nospecialize(E)) = Core.apply_type(Vector, E)
 function kindfor(@nospecialize(ft))
     k = scalarkind(ft)
     k != KIND_UNSUPPORTED && return k
+    if ft isa Union
+        # Nothing/Missing were already peeled: a remaining 2-union is the
+        # classic arraylike-vs-scalar disambiguation shape
+        return KIND_UNION2
+    end
     ft isa DataType || return KIND_UNSUPPORTED
     _isvectortype(ft) && return KIND_VECTOR
-    if isstructtype(ft) && !ismutabletype(ft) && !Base.issingletontype(ft) &&
-       isconcretetype(ft) && !(ft <: AbstractDict) && !(ft <: AbstractArray) &&
-       !(ft <: AbstractSet) && !(ft <: AbstractString) && !(ft <: Tuple) &&
-       !(ft <: NamedTuple) && !(ft <: Function)
+    if getfield(getfield(ft, :name), :wrapper) === Dict &&
+       length(getfield(ft, :parameters)::Core.SimpleVector) == 2
+        return TRIM_BUILD ? KIND_UNSUPPORTED : KIND_DICT
+    end
+    if isstructtype(ft) && !Base.issingletontype(ft) && isconcretetype(ft) &&
+       !(ft <: AbstractDict) && !(ft <: AbstractArray) && !(ft <: AbstractSet) &&
+       !(ft <: AbstractString) && !(ft <: Tuple) && !(ft <: Function)
+        # NamedTuples and (registered) mutables construct through their own
+        # tables like any struct
         return KIND_STRUCT
     end
     return KIND_UNSUPPORTED
@@ -274,7 +302,7 @@ end
 
 function buildtable(@nospecialize(T::Type), style::StructStyle)
     T isa DataType ||
-        return FieldTable(Nothing, FieldSpec[], false, false, nothing, false, true)
+        return FieldTable(Nothing, false, FieldSpec[], false, false, nothing, false, true)
     tagkey = fieldtagkey(style)
     snap = @atomic METASTORE.snap
     meta = _rawmeta(snap, T)
@@ -286,8 +314,10 @@ function buildtable(@nospecialize(T::Type), style::StructStyle)
         # more specific overload (possibly stateful) routes to the classic
         # path, preserving exact semantics
         m = meta::RawMeta
-        metaok = _whichmeta_style(fieldtags, style, T) === m.tagsmethod &&
-                 _whichmeta_style(fielddefaults, style, T) === m.defaultsmethod
+        tm = _whichmeta_style(fieldtags, style, T)
+        dm = _whichmeta_style(fielddefaults, style, T)
+        metaok = m.tagsmethods isa Vector && m.defaultsmethods isa Vector &&
+                 tm in m.tagsmethods && dm in m.defaultsmethods
     end
     local defaults, tags, thunk
     if metaok
@@ -296,6 +326,13 @@ function buildtable(@nospecialize(T::Type), style::StructStyle)
         defaults = valsdefaults ? (;) :
                    m.defaults !== nothing ? m.defaults :
                    (!TRIM_BUILD && thunk !== nothing ? _callthunk(thunk) : (;))
+        if defaults === nothing
+            # the thunk threw: defaults need bound type parameters (e.g.
+            # `ntuple(_ -> 0, N)`), so evaluate per-construct via the
+            # parameterized 3-arg fielddefaults, like vals-dependent defaults
+            valsdefaults = true
+            defaults = (;)
+        end
         tags = m.tags === nothing ? (;) : m.tags
     elseif TRIM_BUILD
         # trimmed binaries cannot consult per-type fielddefaults/fieldtags
@@ -304,92 +341,169 @@ function buildtable(@nospecialize(T::Type), style::StructStyle)
         defaults = (;)
         tags = (;)
         thunk = nothing
+    elseif T <: NamedTuple
+        # NamedTuples carry no macro metadata; reflection is complete
+        defaults = (;)
+        tags = (;)
+        thunk = nothing
     else
         # unregistered (or overridden) type under JIT: the classic path owns
         # it — exact semantics for manual/stateful metadata overloads
-        return FieldTable(T, FieldSpec[], false, false, nothing, false, true)
+        return FieldTable(T, false, FieldSpec[], false, false, nothing, false, true)
     end
-    names = getfield(getfield(T, :name), :names)::Core.SimpleVector
+    isnt = T <: NamedTuple
+    names = isnt ? (T.parameters[1]::Tuple) :
+            getfield(getfield(T, :name), :names)::Core.SimpleVector
     n = fieldcount(T)
     specs = Vector{FieldSpec}(undef, n)
-    eligible = isstructtype(T) && !ismutabletype(T) && !Base.issingletontype(T) &&
-               isconcretetype(T) && n > 0 && !(T <: Tuple) && !(T <: NamedTuple) &&
-               !(T <: AbstractDict) && !(T <: AbstractArray) && !(T <: AbstractSet) &&
-               !(T <: AbstractString) && !(T <: Function) && !(T <: Type)
+    ismut = ismutabletype(T)
+    eligible = isstructtype(T) && !Base.issingletontype(T) && isconcretetype(T) &&
+               n > 0 && !(T <: Tuple) && !(T <: AbstractDict) && !(T <: AbstractArray) &&
+               !(T <: AbstractSet) && !(T <: AbstractString) && !(T <: Function) && !(T <: Type)
+    # mutable targets must be @noarg-registered: their empty constructor is
+    # what applies defaults
+    ismut && !metaok && (eligible = false)
     anythunk = false
     treesafe = true
     for i = 1:n
         fn = names[i]::Symbol
         ftags = _fieldtag_nt(tags, fn, tagkey)
         ignored = _tagbool(ftags, :ignore)
-        nm = _tagname(ftags, fn)
+        nm, aliases = _tagname_aliases(ftags, fn)
+        # exotic name tags route the whole type classic; the reassignment
+        # also keeps `nm` a plain Symbol for the spec constructor
         nm === nothing && (eligible = false; nm = fn)
+        nm = nm::Symbol
         ft0 = fieldtype(T, i)
-        nullable, missingable, ft = peel_nullmissing(ft0)
-        k = ignored ? KIND_UNSUPPORTED : kindfor(ft)
-        if k == KIND_STRUCT
-            fm = _rawmeta(snap, ft)
-            fm !== nothing && (fm::RawMeta).nonstruct && (k = KIND_CUSTOM)
-        end
-        # lift/choosetype/dateformat tags force the dynamic arm
-        if k != KIND_UNSUPPORTED && ftags isa NamedTuple &&
-           (haskey(ftags, :lift) || haskey(ftags, :choosetype) || haskey(ftags, :dateformat))
-            # a choosetype function receives the raw source value; formats
-            # that swap source representations must keep the classic path
-            haskey(ftags, :choosetype) && (treesafe = false)
-            k = KIND_CUSTOM
-        end
-        if k == KIND_UNSUPPORTED && !ignored
-            # a field the interpreter can't produce directly: leaf-ish types
-            # get the dynamic-lift arm; containers/exotics make T ineligible
-            if ft isa DataType && !(ft <: AbstractDict) && !(ft <: AbstractArray) &&
-               !(ft <: AbstractSet) && !(ft <: Tuple) && !(ft <: NamedTuple)
-                k = KIND_CUSTOM
-                # abstract leaves may resolve via a type-level @choosetype,
-                # which also receives the raw source value
-                isconcretetype(ft) || (treesafe = false)
-            else
-                eligible = false
-            end
-        end
-        elk = KIND_UNSUPPORTED
-        elft = nothing
-        if k == KIND_VECTOR
-            elft = _vector_eltype(ft)
-            elk = elft isa Type ? kindfor(elft) : KIND_UNSUPPORTED
-            if elk == KIND_STRUCT
-                em = _rawmeta(snap, elft)
-                em !== nothing && (em::RawMeta).nonstruct && (elk = KIND_CUSTOM)
-            end
-            if elk == KIND_UNSUPPORTED || elk == KIND_VECTOR || elk == KIND_CUSTOM
-                # Vector{exotic}/nested vectors keep today's specialized path;
-                # KIND_CUSTOM elements stay old-path too so per-element lift
-                # tags/choosetype semantics are byte-identical
-                eligible = false
-            end
-        end
+        vs = valuespec(snap, style, ft0, ignored, ftags)
+        vs.kind == KIND_CUSTOM && !isconcretetype(vs.ft) && (treesafe = false)
+        # multidim/fixed-size arrays behave differently from materialized
+        # trees than from lazy sources (dimension discovery): formats that
+        # swap representations must keep such types on their classic path
+        vs.kind == KIND_CUSTOM && vs.ft isa DataType && vs.ft <: AbstractArray &&
+            !_isvectortype(vs.ft) && (treesafe = false)
+        ftags isa NamedTuple && haskey(ftags, :choosetype) && (treesafe = false)
         rawdef = _defaultfor(defaults, fn)
         def = rawdef isa NoDefault ? NODEFAULT : classify_default(rawdef)
+        # an empty-vector default is only re-materializable when the spec
+        # knows the element type; otherwise it needs the thunk
+        def === FRESHEMPTY && vs.kind != KIND_VECTOR && (def = THUNKDEFAULT)
         if def === THUNKDEFAULT
             anythunk = true
         elseif !(rawdef isa NoDefault) && def !== FRESHEMPTY
             def = rawdef
         end
-        specs[i] = FieldSpec(String(nm), nm, fn, k, nullable, missingable, ft, elk, elft, def,
+        specs[i] = FieldSpec(String(nm), nm, fn, aliases, vs, def,
             ftags isa NamedTuple ? ftags : (;))
     end
     if anythunk
         thunk === nothing && (eligible = false)
     end
     valsdefaults && TRIM_BUILD && (eligible = false)
-    return FieldTable(T, specs, eligible, anythunk && !valsdefaults,
+    return FieldTable(T, ismut, specs, eligible, anythunk && !valsdefaults,
         (anythunk && !valsdefaults) ? thunk : nothing, valsdefaults, treesafe)
 end
 
+# build the recursive ValueSpec for one declared type. Unknown shapes degrade
+# to KIND_CUSTOM — the generic 4-arg `make` arm with exact classic semantics
+# (one dynamic call per such value, JIT only) — rather than making the whole
+# type ineligible. Trait consultation is JIT-only; trim builds classify from
+# reflection alone.
+function valuespec(snap::MetaSnap, style::StructStyle, @nospecialize(ft0), ignored::Bool,
+                   @nospecialize(ftags))
+    nullable, missingable, ft = peel_nullmissing(ft0)
+    k = ignored ? KIND_CUSTOM : kindfor(ft)
+    if k == KIND_STRUCT
+        fm = _rawmeta(snap, ft)
+        fm !== nothing && (fm::RawMeta).nonstruct && (k = KIND_CUSTOM)
+        # mutable nested structs construct through their own table
+        !TRIM_BUILD && ft isa DataType && ismutabletype(ft) && !(fm !== nothing) && (k = KIND_CUSTOM)
+    end
+    # lift/choosetype/dateformat tags force the generic arm (field level only)
+    if k != KIND_UNSUPPORTED && ftags isa NamedTuple &&
+       (haskey(ftags, :lift) || haskey(ftags, :choosetype) || haskey(ftags, :dateformat))
+        k = KIND_CUSTOM
+    end
+    keykind = KIND_UNSUPPORTED
+    child = nothing
+    child2 = nothing
+    if k == KIND_VECTOR
+        child = valuespec(snap, style, _vector_eltype(ft), false, nothing)
+        # nested unsupported elements degrade the vector itself to CUSTOM
+        child.kind == KIND_UNSUPPORTED && (k = KIND_CUSTOM; child = nothing)
+    elseif k == KIND_DICT
+        keykind = scalarkind(_dict_keytype(ft))
+        keykind in (KIND_STRING, KIND_SYMBOL, KIND_INT64, KIND_INT32, KIND_INT16,
+            KIND_UINT64, KIND_UINT32, KIND_UINT16, KIND_UINT8) || (k = KIND_CUSTOM)
+        if k == KIND_DICT
+            child = valuespec(snap, style, _dict_valtype(ft), false, nothing)
+            child.kind == KIND_UNSUPPORTED && (k = KIND_CUSTOM; child = nothing)
+        end
+    elseif k == KIND_UNION2
+        a = getfield(ft, :a)
+        b = getfield(ft, :b)
+        # mirror the classic rule exactly: disambiguation applies only when
+        # exactly ONE member is arraylike (by the trait defaults: arrays and
+        # sets) — two arraylike members are ambiguous and take the generic
+        # arm, which reproduces classic behavior including its errors
+        arr_a = _shape_arraylike(a)
+        arr_b = _shape_arraylike(b)
+        if arr_a == arr_b
+            k = KIND_CUSTOM
+        else
+            sa = valuespec(snap, style, a, false, nothing)
+            sb = valuespec(snap, style, b, false, nothing)
+            child = arr_a ? sa : sb   # the arraylike arm
+            child2 = arr_a ? sb : sa  # the scalar arm
+        end
+    end
+    if k == KIND_UNSUPPORTED
+        # anything else — Sets, Matrices, exotic containers, abstract leaves,
+        # UnionAlls — goes through the generic arm rather than poisoning the
+        # containing type. Under trim these fail loudly at parse time.
+        k = KIND_CUSTOM
+    end
+    return ValueSpec(k, nullable, missingable, ft0, ft, keykind, child, child2)
+end
+
+_shape_arraylike(@nospecialize(ft)) =
+    ft isa DataType && (ft <: AbstractArray || ft <: AbstractSet)
+
+_dict_keytype(@nospecialize(ft)) = (getfield(ft, :parameters)::Core.SimpleVector)[1]
+_dict_valtype(@nospecialize(ft)) = (getfield(ft, :parameters)::Core.SimpleVector)[2]
+
+# name tag: Symbol/String rename, or a Tuple of aliases (all become match
+# candidates; first is the canonical write name)
+function _tagname_aliases(@nospecialize(ftags), fn::Symbol)
+    ftags isa NamedTuple || return fn, nothing
+    haskey(ftags, :name) || return fn, nothing
+    nm = getfield(ftags, :name)
+    nm isa Symbol && return nm, nothing
+    nm isa String && return Symbol(nm), nothing
+    if nm isa Tuple && !isempty(nm)
+        strs = String[]
+        for x in nm
+            if x isa String
+                push!(strs, x)
+            elseif x isa Symbol
+                push!(strs, String(x))
+            else
+                return nothing, nothing # exotic alias entry: type goes classic
+            end
+        end
+        syms = Symbol[Symbol(x) for x in strs]
+        return syms[1], (strs, syms)
+    end
+    return nothing, nothing # exotic name tag: type goes classic
+end
+
+# `nothing` on throw: a defaults thunk that cannot evaluate standalone
+# (type-parameter-dependent expressions) signals vals-defaults mode, where
+# construction consults the parameterized 3-arg fielddefaults instead
 _callthunk(@nospecialize(f)) = try
     f()
 catch
-    (;)
+    nothing
 end
 
 # tag helpers on runtime NamedTuples: getfield/haskey on a NamedTuple with a
@@ -481,12 +595,13 @@ _kindname(kind::Int8) = 1 <= kind <= length(KINDNAMES) ? KINDNAMES[kind] : "unsu
     throw(ArgumentError(string("tier-0 interpreter cannot produce a ", _kindname(kind),
         " value for field '", name, "'; annotate the struct `:hot` for the specialized path")))
 
-function _construct_interp(style::StructStyle, tbl::FieldTable, slots::Vector{Any})
+function _construct_interp(style::StructStyle, tbl::FieldTable, slots::Vector{Any}, @nospecialize(source))
+    tbl.mutable && return _construct_mutable(style, tbl, slots, source)
     specs = tbl.specs
     n = length(specs)
     defs = if !TRIM_BUILD && tbl.valsdefaults
-        # defaults referencing parsed fields: evaluate against the slots,
-        # exactly like the classic _construct slow path
+        # defaults referencing parsed fields (or bound type parameters):
+        # evaluate against the slots, exactly like the classic slow path
         fielddefaults(style, tbl.T, slots)
     elseif !TRIM_BUILD && tbl.anythunk
         _callthunk(tbl.defaultsthunk)
@@ -498,24 +613,24 @@ function _construct_interp(style::StructStyle, tbl::FieldTable, slots::Vector{An
         sp = @inbounds specs[i]
         d = tbl.valsdefaults ? THUNKDEFAULT : sp.default
         if d === NODEFAULT
-            if sp.nullable
+            if sp.spec.nullable
                 slots[i] = nothing
-            elseif sp.missingable
+            elseif sp.spec.missingable
                 slots[i] = missing
             else
                 _missingfield(sp.name, tbl.T)
             end
         elseif d === FRESHEMPTY
-            slots[i] = _alloc_vector(sp.elft, 0)
+            slots[i] = _alloc_vector((sp.spec.child::ValueSpec).declft, 0)
         elseif d === THUNKDEFAULT
             if TRIM_BUILD
                 _missingfield(sp.name, tbl.T)
             else
                 d2 = _defaultfor(defs, sp.fieldsym)
                 if d2 isa NoDefault
-                    if sp.nullable
+                    if sp.spec.nullable
                         slots[i] = nothing
-                    elseif sp.missingable
+                    elseif sp.spec.missingable
                         slots[i] = missing
                     else
                         _missingfield(sp.name, tbl.T)
@@ -531,6 +646,39 @@ function _construct_interp(style::StructStyle, tbl::FieldTable, slots::Vector{An
     GC.@preserve slots begin
         return ccall(:jl_new_structv, Any, (Any, Ptr{Any}, UInt32), tbl.T, pointer(slots), n % UInt32)
     end
+end
+
+# @noarg mutables: the empty constructor applies defaults (honoring
+# per-style `initialize` overloads under JIT), parsed slots overwrite via
+# the setfield! builtin. Trim builds construct uninitialized and apply the
+# table defaults instead — `initialize` overloads are a JIT-only nicety.
+function _construct_mutable(style::StructStyle, tbl::FieldTable, slots::Vector{Any}, @nospecialize(source))
+    specs = tbl.specs
+    n = length(specs)
+    local obj
+    if TRIM_BUILD
+        obj = ccall(:jl_new_struct_uninit, Any, (Any,), tbl.T)
+        for i = 1:n
+            isassigned(slots, i) && continue
+            sp = @inbounds specs[i]
+            d = sp.default
+            if d === NODEFAULT
+                sp.spec.nullable ? setfield!(obj, i, nothing) :
+                sp.spec.missingable ? setfield!(obj, i, missing) : nothing
+            elseif d === FRESHEMPTY
+                setfield!(obj, i, _alloc_vector((sp.spec.child::ValueSpec).declft, 0))
+            elseif d !== THUNKDEFAULT
+                setfield!(obj, i, d)
+            end
+        end
+    else
+        obj = initialize(style, tbl.T, source)
+    end
+    for i = 1:n
+        isassigned(slots, i) || continue
+        setfield!(obj, i, @inbounds slots[i])
+    end
+    return obj
 end
 
 # ---------------- leaf lifting (closed kinds; exact-typed results) ----------------
@@ -696,7 +844,8 @@ end
 function _findspec(specs::Vector{FieldSpec}, @nospecialize(k))
     if k isa Symbol
         for i = 1:length(specs)
-            @inbounds(specs[i]).namesym === k && return i
+            sp = @inbounds specs[i]
+            (sp.namesym === k || sp.fieldsym === k) && return i
         end
     elseif k isa String
         for i = 1:length(specs)
@@ -707,6 +856,22 @@ function _findspec(specs::Vector{FieldSpec}, @nospecialize(k))
         for i = 1:length(specs)
             keyeq(k, @inbounds(specs[i]).name) && return i
         end
+        return 0
+    end
+    # rare path: tuple-alias name tags register extra match candidates
+    for i = 1:length(specs)
+        al = @inbounds(specs[i]).aliases
+        al === nothing && continue
+        strs, syms = al::Tuple{Vector{String},Vector{Symbol}}
+        if k isa Symbol
+            for a in syms
+                a === k && return i
+            end
+        elseif k isa String
+            for a in strs
+                a == k && return i
+            end
+        end
     end
     return 0
 end
@@ -716,15 +881,16 @@ function (f::InterpClosure{S})(@nospecialize(k), @nospecialize(v)) where {S}
     i = _findspec(specs, k)
     i == 0 && return unknownfield(f.style, f.tbl.T, k, v)
     sp = @inbounds specs[i]
-    if v === nothing && sp.kind != KIND_ANY && sp.kind != KIND_CUSTOM
-        if sp.nullable
+    vs = sp.spec
+    if v === nothing && vs.kind != KIND_ANY && vs.kind != KIND_CUSTOM
+        if vs.nullable
             f.slots[i] = nothing
-        elseif sp.missingable
+        elseif vs.missingable
             f.slots[i] = missing
         elseif TRIM_BUILD
-            _liftfail(sp.kind, sp.name)
+            _liftfail(vs.kind, sp.name)
         else
-            x, _ = lift(f.style, sp.ft, nothing)
+            x, _ = lift(f.style, vs.ft, nothing)
             f.slots[i] = x
         end
         return defaultstate(f.style)
@@ -733,8 +899,26 @@ function (f::InterpClosure{S})(@nospecialize(k), @nospecialize(v)) where {S}
     return defaultstate(f.style)
 end
 
+# field-level entry: CUSTOM here carries the field's tags; everything else
+# recurses through the spec tree
 function _interp_value(style::StructStyle, sp::FieldSpec, @nospecialize(v))
-    k = sp.kind
+    vs = sp.spec
+    if vs.kind == KIND_CUSTOM
+        if TRIM_BUILD
+            _liftfail(vs.kind, sp.name)
+        else
+            # the 4-arg make with the field's resolved tags, so lift/
+            # choosetype/dateformat tags keep their classic semantics
+            x, _ = make(style, vs.declft::Type, v, sp.tags)
+            return x
+        end
+    end
+    return _spec_value(style, vs, v, sp.name)
+end
+
+# position-level recursion over the ValueSpec tree
+function _spec_value(style::StructStyle, vs::ValueSpec, @nospecialize(v), name::String)
+    k = vs.kind
     if k == KIND_STRUCT
         if TRIM_BUILD
             # direct recursion with a closed nested-source ladder: concrete
@@ -742,90 +926,130 @@ function _interp_value(style::StructStyle, sp::FieldSpec, @nospecialize(v))
             # with their own tree types route their sources at their own
             # entry, e.g. JSON drives Object roots through `make` directly)
             if v isa Dict{String,Any}
-                x, _ = _interp_make(style, sp.ft, v)
+                x, _ = _interp_make(style, vs.ft, v)
                 return x
             elseif v isa Dict{Symbol,Any}
-                x, _ = _interp_make(style, sp.ft, v)
+                x, _ = _interp_make(style, vs.ft, v)
                 return x
             else
-                _liftfail(k, sp.name)
+                _liftfail(k, name)
             end
         else
             # JIT: route through the dispatcher so per-style trait overloads
             # (dictlike/arraylike/noarg/structlike) keep exact semantics; it
             # re-enters the interpreter through the gate when appropriate
-            x, _ = make(style, sp.ft::Type, v)
+            x, _ = make(style, vs.ft::Type, v)
             return x
         end
     elseif k == KIND_VECTOR
-        return _interp_vector(style, sp, v)
+        return _spec_vector(style, vs, v, name)
+    elseif k == KIND_DICT
+        # JIT-only (kindfor never yields KIND_DICT in trim builds, but the
+        # arm must be compile-time dead or its dynamic innards stay
+        # verifier-reachable)
+        if TRIM_BUILD
+            _liftfail(k, name)
+        else
+            return _spec_dict(style, vs, v, name)
+        end
+    elseif k == KIND_UNION2
+        # the classic arraylike-vs-scalar two-union rule, by source shape
+        arm = (v isa AbstractArray || v isa AbstractSet) ? (vs.child::ValueSpec) :
+                                                           (vs.child2::ValueSpec)
+        return _spec_nullwrap(style, arm, v, name)
     elseif k == KIND_ANY
         return v
     elseif k == KIND_CUSTOM
         if TRIM_BUILD
-            _liftfail(k, sp.name)
+            _liftfail(k, name)
         else
-            # the 4-arg make with the field's resolved tags, so lift/
-            # choosetype/dateformat tags keep their classic semantics
-            x, _ = make(style, sp.ft::Type, v, sp.tags)
+            # element/value-position generic arm: classic containers recurse
+            # through the tagless 3-arg make
+            x, _ = make(style, vs.declft::Type, v)
             return x
         end
     else
-        return _liftleaf(style, k, sp.ft, v, sp.name)
+        return _liftleaf(style, k, vs.ft, v, name)
     end
 end
 
-function _interp_vecel(style::StructStyle, elk::Int8, @nospecialize(elft), @nospecialize(ev), name::String)
-    if elk == KIND_STRUCT
-        if TRIM_BUILD
-            if ev isa Dict{String,Any}
-                x, _ = _interp_make(style, elft, ev)
-                return x
-            elseif ev isa Dict{Symbol,Any}
-                x, _ = _interp_make(style, elft, ev)
-                return x
-            else
-                _liftfail(elk, name)
-            end
-        else
-            x, _ = make(style, elft::Type, ev)
-            return x
-        end
-    elseif elk == KIND_ANY
-        return ev
-    else
-        return _liftleaf(style, elk, elft, ev, name)
+# nested positions can themselves be nullable (e.g. Vector{Union{T,Nothing}}
+# elements, union arms)
+function _spec_nullwrap(style::StructStyle, vs::ValueSpec, @nospecialize(v), name::String)
+    if v === nothing && vs.kind != KIND_ANY && vs.kind != KIND_CUSTOM
+        vs.nullable && return nothing
+        vs.missingable && return missing
+        TRIM_BUILD && _liftfail(vs.kind, name)
+        x, _ = lift(style, vs.ft, nothing)
+        return x
     end
+    return _spec_value(style, vs, v, name)
 end
 
-function _interp_vector(style::StructStyle, sp::FieldSpec, @nospecialize(v))
-    elk = sp.elkind
-    elft = sp.elft
+function _spec_vector(style::StructStyle, vs::ValueSpec, @nospecialize(v), name::String)
+    el = vs.child::ValueSpec
     if v isa Vector{Any}
         n = length(v)
-        arr = _alloc_vector(elft, n)
+        arr = _alloc_vector(el.declft, n)
         for j = 1:n
-            _setvec!(arr, j, _interp_vecel(style, elk, elft, @inbounds(v[j]), sp.name))
+            _setvec!(arr, j, _spec_nullwrap(style, el, @inbounds(v[j]), name))
         end
         return arr
     elseif !TRIM_BUILD && v isa AbstractVector
         # generic source vectors (e.g. a Vector{Int} value inside a user Dict)
         n = length(v)
-        arr = _alloc_vector(elft, n)
+        arr = _alloc_vector(el.declft, n)
         j = 1
         for ev in v
-            _setvec!(arr, j, _interp_vecel(style, elk, elft, ev, sp.name))
+            _setvec!(arr, j, _spec_nullwrap(style, el, ev, name))
             j += 1
         end
         return arr
     end
     if TRIM_BUILD
-        _liftfail(elk, sp.name)
+        _liftfail(vs.kind, name)
     else
-        # non-vector source for a vector field: today's generic path decides
-        x, _ = make(style, _vectype(elft), v)
+        # non-vector source for a vector field: the generic path decides
+        x, _ = make(style, vs.declft::Type, v)
         return x
     end
+end
+
+# Dict-typed fields (JIT only; kindfor never yields KIND_DICT under trim):
+# `initialize` honors per-style sizehints/overloads, keys lift per keykind,
+# values recurse through the child spec
+function _spec_dict(style::StructStyle, vs::ValueSpec, @nospecialize(v), name::String)
+    el = vs.child::ValueSpec
+    dict = initialize(style, vs.ft, v)
+    if v isa AbstractDict
+        for (dk, dv) in v
+            addkeyval!(dict, _liftdictkey(style, vs, dk, name), _spec_nullwrap(style, el, dv, name))
+        end
+    elseif v isa AbstractVector{<:Pair}
+        for (dk, dv) in v
+            addkeyval!(dict, _liftdictkey(style, vs, dk, name), _spec_nullwrap(style, el, dv, name))
+        end
+    else
+        x, _ = make(style, vs.declft::Type, v)
+        return x
+    end
+    return dict
+end
+
+function _liftdictkey(style::StructStyle, vs::ValueSpec, @nospecialize(dk), name::String)
+    kk = vs.keykind
+    if kk == KIND_STRING
+        dk isa String && return dk
+        dk isa Symbol && return String(dk)
+    elseif kk == KIND_SYMBOL
+        dk isa Symbol && return dk
+        dk isa String && return Symbol(dk)
+    elseif dk isa String && (kk == KIND_INT64 || kk == KIND_INT32 || kk == KIND_INT16 ||
+           kk == KIND_UINT64 || kk == KIND_UINT32 || kk == KIND_UINT16 || kk == KIND_UINT8)
+        return _liftleaf(style, kk, _dict_keytype(vs.ft), Base.parse(Int64, dk), name)
+    end
+    # odd pairings: the style's liftkey hook decides (JIT)
+    return liftkey(style, _dict_keytype(vs.ft), dk)
 end
 
 # true when `source` is a tree shape the interpreter drives directly; under
@@ -863,7 +1087,7 @@ Base.@nospecializeinfer function _interp_make(style::StructStyle, @nospecialize(
     end
     # match makestruct: EarlyReturn from a custom unknownfield flows through
     # as state; construction still happens
-    return _construct_interp(style, tbl, slots), st
+    return _construct_interp(style, tbl, slots, source), st
 end
 
 # gate consulted from `make`'s structlike arm: interpret when the target has
@@ -904,11 +1128,14 @@ function _treesafe(style::StructStyle, @nospecialize(T), seen::Base.IdSet{Any}):
     tbl.eligible || return true # routed classic anyway
     tbl.treesafe || return false
     for sp in tbl.specs
-        if sp.kind == KIND_STRUCT
-            _treesafe(style, sp.ft, seen) || return false
-        elseif sp.kind == KIND_VECTOR && sp.elkind == KIND_STRUCT
-            _treesafe(style, sp.elft, seen) || return false
-        end
+        _spec_treesafe(style, sp.spec, seen) || return false
     end
+    return true
+end
+
+function _spec_treesafe(style::StructStyle, vs::ValueSpec, seen::Base.IdSet{Any})::Bool
+    vs.kind == KIND_STRUCT && return _treesafe(style, vs.ft, seen)
+    vs.child isa ValueSpec && !_spec_treesafe(style, vs.child::ValueSpec, seen) && return false
+    vs.child2 isa ValueSpec && !_spec_treesafe(style, vs.child2::ValueSpec, seen) && return false
     return true
 end

--- a/src/interp.jl
+++ b/src/interp.jl
@@ -47,6 +47,9 @@ const KIND_CUSTOM = Int8(25)
 const KIND_DICT = Int8(26)
 const KIND_SET = Int8(27)
 const KIND_UNION2 = Int8(28)
+const KIND_TUPLE = Int8(29)
+const KIND_FIXEDARRAY = Int8(30)
+const KIND_SETLIKE = Int8(31)
 
 function scalarkind(@nospecialize(ft))
     ft === String && return KIND_STRING
@@ -118,10 +121,11 @@ struct FieldTable
     defaultsthunk::Any     # () -> NamedTuple, or nothing
     valsdefaults::Bool     # defaults reference parsed fields: use the 3-arg
                            # fielddefaults(style, T, vals) semantics (JIT only)
-    treesafe::Bool         # own fields free of choosetype tags and abstract
-                           # CUSTOM leaves: those hand the *source* to user
-                           # functions, whose representation formats may not
-                           # change (see interptreesafe for the recursive check)
+    volatile::Bool         # metadata comes from live per-type methods
+                           # (unregistered types, or overloads more specific
+                           # than the registration): rebuild per make so
+                           # stateful fieldtags/fielddefaults keep their
+                           # call-per-make semantics; never cached
 end
 
 # raw per-type metadata as registered by the struct macros: plain data, so
@@ -143,6 +147,9 @@ end
 # the hot path of every structlike `make`)
 struct MetaSnap
     raw::IdDict{Any,RawMeta}
+    # (target type) => [(style type) => root ValueSpec] for non-struct
+    # targets (containers, tuples) driven through the interpreter directly
+    roots::IdDict{Any,Vector{Pair{DataType,Any}}}
     # (target type) => [(style type) => resolved table]; per style TYPE
     # because fieldtagkey namespacing and metadata-method resolution are
     # style-dependent
@@ -154,6 +161,7 @@ mutable struct MetaStore
 end
 
 const METASTORE = MetaStore(MetaSnap(IdDict{Any,RawMeta}(),
+    IdDict{Any,Vector{Pair{DataType,Any}}}(),
     IdDict{Any,Vector{Pair{DataType,FieldTable}}}()))
 const META_LOCK = ReentrantLock()
 
@@ -197,7 +205,9 @@ function register_fieldtable!(@nospecialize(T::Type); defaults=nothing, tags=not
         raw[T] = RawMeta(nt, defaults, tags, nonstruct, tm, dm, valsdependent)
         tables = copy(old.tables)
         empty!(tables) # invalidate resolved tables (nested kinds may change)
-        @atomic METASTORE.snap = MetaSnap(raw, tables)
+        roots = copy(old.roots)
+        empty!(roots)
+        @atomic METASTORE.snap = MetaSnap(raw, roots, tables)
     finally
         unlock(META_LOCK)
     end
@@ -266,6 +276,12 @@ function kindfor(@nospecialize(ft))
     end
     ft isa DataType || return KIND_UNSUPPORTED
     _isvectortype(ft) && return KIND_VECTOR
+    if !TRIM_BUILD
+        ft <: Tuple && isconcretetype(ft) && return KIND_TUPLE
+        ft <: AbstractSet && isconcretetype(ft) && return KIND_SETLIKE
+        ft <: AbstractArray && isconcretetype(ft) && !(ft <: AbstractVector) &&
+            return KIND_FIXEDARRAY
+    end
     if getfield(getfield(ft, :name), :wrapper) === Dict &&
        length(getfield(ft, :parameters)::Core.SimpleVector) == 2
         return TRIM_BUILD ? KIND_UNSUPPORTED : KIND_DICT
@@ -302,11 +318,12 @@ end
 
 function buildtable(@nospecialize(T::Type), style::StructStyle)
     T isa DataType ||
-        return FieldTable(Nothing, false, FieldSpec[], false, false, nothing, false, true)
+        return FieldTable(Nothing, false, FieldSpec[], false, false, nothing, false, false)
     tagkey = fieldtagkey(style)
     snap = @atomic METASTORE.snap
     meta = _rawmeta(snap, T)
     metaok = meta !== nothing
+    volatile = false
     valsdefaults = metaok && (meta::RawMeta).valsdependent
     if metaok && !TRIM_BUILD
         # the registered data is only valid while it is still what
@@ -347,9 +364,14 @@ function buildtable(@nospecialize(T::Type), style::StructStyle)
         tags = (;)
         thunk = nothing
     else
-        # unregistered (or overridden) type under JIT: the classic path owns
-        # it — exact semantics for manual/stateful metadata overloads
-        return FieldTable(T, false, FieldSpec[], false, false, nothing, false, true)
+        # unregistered (or overridden) type under JIT: consult the live
+        # per-type metadata methods, and mark the table volatile — it is
+        # rebuilt on every make, so stateful or later-redefined
+        # fieldtags/fielddefaults overloads keep their exact semantics
+        volatile = true
+        defaults = fielddefaults(style, T)
+        tags = _live_tags(style, T)
+        thunk = () -> fielddefaults(style, T)
     end
     isnt = T <: NamedTuple
     names = isnt ? (T.parameters[1]::Tuple) :
@@ -364,25 +386,23 @@ function buildtable(@nospecialize(T::Type), style::StructStyle)
     # what applies defaults
     ismut && !metaok && (eligible = false)
     anythunk = false
-    treesafe = true
     for i = 1:n
         fn = names[i]::Symbol
         ftags = _fieldtag_nt(tags, fn, tagkey)
+        if ftags === nothing && volatile && tags isa NamedTuple && isempty(tags)
+            # public per-field form: fieldtags(style, T, field) — consulted
+            # only when the whole-type form answers empty (mirroring
+            # _fieldtagtuple); the table is already volatile, so stateful
+            # per-field hooks keep their call-per-make semantics
+            pf = _live_pertags(style, T, fn)
+            pf isa NamedTuple && !isempty(pf) && (ftags = pf)
+        end
         ignored = _tagbool(ftags, :ignore)
         nm, aliases = _tagname_aliases(ftags, fn)
-        # exotic name tags route the whole type classic; the reassignment
-        # also keeps `nm` a plain Symbol for the spec constructor
-        nm === nothing && (eligible = false; nm = fn)
-        nm = nm::Symbol
+        # raw-key matching is a JIT facility; trim builds keep such types out
+        aliases isa RawKey && TRIM_BUILD && (eligible = false)
         ft0 = fieldtype(T, i)
         vs = valuespec(snap, style, ft0, ignored, ftags)
-        vs.kind == KIND_CUSTOM && !isconcretetype(vs.ft) && (treesafe = false)
-        # multidim/fixed-size arrays behave differently from materialized
-        # trees than from lazy sources (dimension discovery): formats that
-        # swap representations must keep such types on their classic path
-        vs.kind == KIND_CUSTOM && vs.ft isa DataType && vs.ft <: AbstractArray &&
-            !_isvectortype(vs.ft) && (treesafe = false)
-        ftags isa NamedTuple && haskey(ftags, :choosetype) && (treesafe = false)
         rawdef = _defaultfor(defaults, fn)
         def = rawdef isa NoDefault ? NODEFAULT : classify_default(rawdef)
         # an empty-vector default is only re-materializable when the spec
@@ -401,7 +421,7 @@ function buildtable(@nospecialize(T::Type), style::StructStyle)
     end
     valsdefaults && TRIM_BUILD && (eligible = false)
     return FieldTable(T, ismut, specs, eligible, anythunk && !valsdefaults,
-        (anythunk && !valsdefaults) ? thunk : nothing, valsdefaults, treesafe)
+        (anythunk && !valsdefaults) ? thunk : nothing, valsdefaults, volatile)
 end
 
 # build the recursive ValueSpec for one declared type. Unknown shapes degrade
@@ -413,9 +433,26 @@ function valuespec(snap::MetaSnap, style::StructStyle, @nospecialize(ft0), ignor
                    @nospecialize(ftags))
     nullable, missingable, ft = peel_nullmissing(ft0)
     k = ignored ? KIND_CUSTOM : kindfor(ft)
+    # pair-element vectors are dictlike by the trait ladder (built via
+    # addkeyval! push): the retained container machinery owns them
+    k == KIND_VECTOR && ft isa Type && ft <: AbstractVector{<:Pair} && (k = KIND_CUSTOM)
     if k == KIND_STRUCT
         fm = _rawmeta(snap, ft)
         fm !== nothing && (fm::RawMeta).nonstruct && (k = KIND_CUSTOM)
+        # @nonstruct also emits a structlike=false trait method, which
+        # persists in the defining package's image even when the registry
+        # mutation from its precompile session does not: honor it live
+        # (JIT-only: under juliac the single compile session keeps the
+        # registry authoritative)
+        !TRIM_BUILD && k == KIND_STRUCT && !structlike(style, ft) && (k = KIND_CUSTOM)
+        # types with their own `make` overloads (e.g. JSON's raw-capture
+        # JSONText) must stay on the generic arm — driving their fields
+        # through the interpreter would silently bypass user semantics
+        !TRIM_BUILD && k == KIND_STRUCT && _has_custom_make(ft) && (k = KIND_CUSTOM)
+        # style-level trait overrides outrank the structural classification:
+        # a struct the style declares dictlike/arraylike belongs to the
+        # dispatcher's container arms, not the field-table drive
+        !TRIM_BUILD && k == KIND_STRUCT && (dictlike(style, ft) || arraylike(style, ft)) && (k = KIND_CUSTOM)
         # mutable nested structs construct through their own table
         !TRIM_BUILD && ft isa DataType && ismutabletype(ft) && !(fm !== nothing) && (k = KIND_CUSTOM)
     end
@@ -437,6 +474,21 @@ function valuespec(snap::MetaSnap, style::StructStyle, @nospecialize(ft0), ignor
             KIND_UINT64, KIND_UINT32, KIND_UINT16, KIND_UINT8) || (k = KIND_CUSTOM)
         if k == KIND_DICT
             child = valuespec(snap, style, _dict_valtype(ft), false, nothing)
+            child.kind == KIND_UNSUPPORTED && (k = KIND_CUSTOM; child = nothing)
+        end
+    elseif k == KIND_TUPLE
+        members = StructUtils.ValueSpec[valuespec(snap, style, fieldtype(ft, i), false, nothing)
+                                        for i = 1:fieldcount(ft)]
+        any(m -> m.kind == KIND_UNSUPPORTED, members) ? (k = KIND_CUSTOM) : (child = members)
+    elseif k == KIND_SETLIKE || k == KIND_FIXEDARRAY
+        if TRIM_BUILD
+            # JIT-only kinds: the generic eltype below is not verifier-
+            # resolvable; trim keeps sets and fixed-size arrays on the
+            # generic arm (their pre-expansion behavior)
+            k = KIND_CUSTOM
+        else
+            elt = eltype(ft)
+            child = valuespec(snap, style, elt, false, nothing)
             child.kind == KIND_UNSUPPORTED && (k = KIND_CUSTOM; child = nothing)
         end
     elseif k == KIND_UNION2
@@ -488,13 +540,19 @@ function _tagname_aliases(@nospecialize(ftags), fn::Symbol)
             elseif x isa Symbol
                 push!(strs, String(x))
             else
-                return nothing, nothing # exotic alias entry: type goes classic
+                return fn, RawKey(nm) # exotic entry: generic keyeq match
             end
         end
         syms = Symbol[Symbol(x) for x in strs]
         return syms[1], (strs, syms)
     end
-    return nothing, nothing # exotic name tag: type goes classic
+    return fn, RawKey(nm) # exotic name tag: generic keyeq match
+end
+
+# wrapper marking a name tag the fast matchers can't table-ize; _findspec
+# falls back to the classic keyeq contract for these (JIT only)
+struct RawKey
+    x::Any
 end
 
 # `nothing` on throw: a defaults thunk that cannot evaluate standalone
@@ -538,6 +596,31 @@ function _defaultfor(@nospecialize(defaults), fn::Symbol)
     return getfield(defaults, fn)
 end
 
+_live_tags(style::StructStyle, @nospecialize(T)) = try
+    fieldtags(style, T)
+catch
+    (;)
+end
+
+# a `make` method more specific than the generic dispatcher exists for T:
+# checked once per table build (cached with the table; volatile tables are
+# already the deliberate slow path). Queried with the CONCRETE Type{T}
+# singleton — a `Type{<:T}` query would intersect every emitted
+# `make(::StructStyle, ::Type{S}, ::Any) where S<:Other` method through the
+# bottom type (S = Union{} inhabits both bounds)
+_has_custom_make(@nospecialize(T)) = try
+    generic = which(make, Tuple{StructStyle,Type,Any})
+    any(m -> m !== generic, methods(make, Tuple{StructStyle,Type{T},Any}))
+catch
+    false
+end
+
+_live_pertags(style::StructStyle, @nospecialize(T), fn::Symbol) = try
+    fieldtags(style, T, fn)
+catch
+    (;)
+end
+
 function fieldtable(@nospecialize(T::Type), style::StructStyle)
     styletype = typeof(style)
     snap = @atomic METASTORE.snap
@@ -548,6 +631,7 @@ function fieldtable(@nospecialize(T::Type), style::StructStyle)
         end
     end
     tbl = buildtable(T, style)
+    tbl.volatile && return tbl # live-metadata tables are never cached
     lock(META_LOCK)
     try
         old = @atomic METASTORE.snap
@@ -561,7 +645,7 @@ function fieldtable(@nospecialize(T::Type), style::StructStyle)
         if !found
             push!(v, styletype => tbl)
             tables[T] = v
-            @atomic METASTORE.snap = MetaSnap(old.raw, tables)
+            @atomic METASTORE.snap = MetaSnap(old.raw, old.roots, tables)
         end
     finally
         unlock(META_LOCK)
@@ -650,8 +734,9 @@ end
 
 # @noarg mutables: the empty constructor applies defaults (honoring
 # per-style `initialize` overloads under JIT), parsed slots overwrite via
-# the setfield! builtin. Trim builds construct uninitialized and apply the
-# table defaults instead — `initialize` overloads are a JIT-only nicety.
+# _setfield! (which honors @atomic field declarations). Trim builds
+# construct uninitialized and apply the table defaults instead —
+# `initialize` overloads are a JIT-only nicety.
 function _construct_mutable(style::StructStyle, tbl::FieldTable, slots::Vector{Any}, @nospecialize(source))
     specs = tbl.specs
     n = length(specs)
@@ -663,12 +748,12 @@ function _construct_mutable(style::StructStyle, tbl::FieldTable, slots::Vector{A
             sp = @inbounds specs[i]
             d = sp.default
             if d === NODEFAULT
-                sp.spec.nullable ? setfield!(obj, i, nothing) :
-                sp.spec.missingable ? setfield!(obj, i, missing) : nothing
+                sp.spec.nullable ? _setfield!(obj, i, nothing) :
+                sp.spec.missingable ? _setfield!(obj, i, missing) : nothing
             elseif d === FRESHEMPTY
-                setfield!(obj, i, _alloc_vector((sp.spec.child::ValueSpec).declft, 0))
+                _setfield!(obj, i, _alloc_vector((sp.spec.child::ValueSpec).declft, 0))
             elseif d !== THUNKDEFAULT
-                setfield!(obj, i, d)
+                _setfield!(obj, i, d)
             end
         end
     else
@@ -676,7 +761,7 @@ function _construct_mutable(style::StructStyle, tbl::FieldTable, slots::Vector{A
     end
     for i = 1:n
         isassigned(slots, i) || continue
-        setfield!(obj, i, @inbounds slots[i])
+        _setfield!(obj, i, @inbounds slots[i])
     end
     return obj
 end
@@ -842,7 +927,11 @@ struct InterpClosure{S<:StructStyle}
 end
 
 function _findspec(specs::Vector{FieldSpec}, @nospecialize(k))
-    if k isa Symbol
+    if k isa Int
+        # positional sources (Vector/Tuple elements via applyeach): index is
+        # field order, matching the classic closures' `k == i` arm
+        return 1 <= k <= length(specs) ? k : 0
+    elseif k isa Symbol
         for i = 1:length(specs)
             sp = @inbounds specs[i]
             (sp.namesym === k || sp.fieldsym === k) && return i
@@ -858,10 +947,14 @@ function _findspec(specs::Vector{FieldSpec}, @nospecialize(k))
         end
         return 0
     end
-    # rare path: tuple-alias name tags register extra match candidates
+    # rare path: alias tuples and raw name tags register extra candidates
     for i = 1:length(specs)
         al = @inbounds(specs[i]).aliases
         al === nothing && continue
+        if al isa RawKey
+            !TRIM_BUILD && keyeq(k, al.x) && return i
+            continue
+        end
         strs, syms = al::Tuple{Vector{String},Vector{Symbol}}
         if k isa Symbol
             for a in syms
@@ -883,14 +976,31 @@ function (f::InterpClosure{S})(@nospecialize(k), @nospecialize(v)) where {S}
     sp = @inbounds specs[i]
     vs = sp.spec
     if v === nothing && vs.kind != KIND_ANY && vs.kind != KIND_CUSTOM
-        if vs.nullable
-            f.slots[i] = nothing
-        elseif vs.missingable
+        # classic @_peel order: null-like sources take the Missing arm
+        # first when the field admits both
+        if vs.missingable
             f.slots[i] = missing
+        elseif vs.nullable
+            f.slots[i] = nothing
         elseif TRIM_BUILD
             _liftfail(vs.kind, sp.name)
         else
             x, _ = lift(f.style, vs.ft, nothing)
+            f.slots[i] = x
+        end
+        return defaultstate(f.style)
+    elseif v === missing && vs.kind != KIND_ANY && vs.kind != KIND_CUSTOM
+        # classic @_peel parity: missing is null-like, Missing arm first.
+        # Kept as a separate branch with a CONSTANT third argument so the
+        # lift dispatch narrows to a single method under the verifier.
+        if vs.missingable
+            f.slots[i] = missing
+        elseif vs.nullable
+            f.slots[i] = nothing
+        elseif TRIM_BUILD
+            _liftfail(vs.kind, sp.name)
+        else
+            x, _ = lift(f.style, vs.ft, missing)
             f.slots[i] = x
         end
         return defaultstate(f.style)
@@ -957,6 +1067,34 @@ function _spec_value(style::StructStyle, vs::ValueSpec, @nospecialize(v), name::
         arm = (v isa AbstractArray || v isa AbstractSet) ? (vs.child::ValueSpec) :
                                                            (vs.child2::ValueSpec)
         return _spec_nullwrap(style, arm, v, name)
+    elseif k == KIND_TUPLE
+        if TRIM_BUILD
+            _liftfail(k, name)
+        else
+            return _spec_tuple(style, vs, v, name)
+        end
+    elseif k == KIND_SETLIKE
+        if TRIM_BUILD
+            _liftfail(k, name)
+        else
+            set = initialize(style, vs.ft, v)
+            el = vs.child::ValueSpec
+            if v isa AbstractVector || v isa AbstractSet
+                for ev in v
+                    push!(set, _spec_nullwrap(style, el, ev, name))
+                end
+                return set
+            end
+            TRIM_BUILD && _liftfail(vs.kind, name)
+            x, _ = makearray(style, vs.declft, v)
+            return x
+        end
+    elseif k == KIND_FIXEDARRAY
+        if TRIM_BUILD
+            _liftfail(k, name)
+        else
+            return _spec_fixedarray(style, vs, v, name)
+        end
     elseif k == KIND_ANY
         return v
     elseif k == KIND_CUSTOM
@@ -977,10 +1115,18 @@ end
 # elements, union arms)
 function _spec_nullwrap(style::StructStyle, vs::ValueSpec, @nospecialize(v), name::String)
     if v === nothing && vs.kind != KIND_ANY && vs.kind != KIND_CUSTOM
-        vs.nullable && return nothing
+        # classic @_peel order: Missing arm first when both are admitted
         vs.missingable && return missing
+        vs.nullable && return nothing
         TRIM_BUILD && _liftfail(vs.kind, name)
         x, _ = lift(style, vs.ft, nothing)
+        return x
+    elseif v === missing && vs.kind != KIND_ANY && vs.kind != KIND_CUSTOM
+        # classic @_peel: missing is null-like, the Missing arm wins first
+        vs.missingable && return missing
+        vs.nullable && return nothing
+        TRIM_BUILD && _liftfail(vs.kind, name)
+        x, _ = lift(style, vs.ft, missing)
         return x
     end
     return _spec_value(style, vs, v, name)
@@ -995,8 +1141,9 @@ function _spec_vector(style::StructStyle, vs::ValueSpec, @nospecialize(v), name:
             _setvec!(arr, j, _spec_nullwrap(style, el, @inbounds(v[j]), name))
         end
         return arr
-    elseif !TRIM_BUILD && v isa AbstractVector
-        # generic source vectors (e.g. a Vector{Int} value inside a user Dict)
+    elseif !TRIM_BUILD && v isa AbstractVector && !(v isa AbstractVector{<:Pair})
+        # generic source vectors (e.g. a Vector{Int} value inside a user Dict);
+        # pair-element vectors are keyed sources and fall to makearray below
         n = length(v)
         arr = _alloc_vector(el.declft, n)
         j = 1
@@ -1009,8 +1156,11 @@ function _spec_vector(style::StructStyle, vs::ValueSpec, @nospecialize(v), name:
     if TRIM_BUILD
         _liftfail(vs.kind, name)
     else
-        # non-vector source for a vector field: the generic path decides
-        x, _ = make(style, vs.declft::Type, v)
+        # non-vector source: the retained container machinery owns it
+        # (calling `make` would re-enter _interp_root on the same spec);
+        # trim fails loudly on shapes its folded path can't drive
+        TRIM_BUILD && _liftfail(vs.kind, name)
+        x, _ = makearray(style, vs.declft, v)
         return x
     end
 end
@@ -1030,10 +1180,90 @@ function _spec_dict(style::StructStyle, vs::ValueSpec, @nospecialize(v), name::S
             addkeyval!(dict, _liftdictkey(style, vs, dk, name), _spec_nullwrap(style, el, dv, name))
         end
     else
-        x, _ = make(style, vs.declft::Type, v)
+        TRIM_BUILD && _liftfail(vs.kind, name)
+        x, _ = makedict(style, vs.declft, v)
         return x
     end
     return dict
+end
+
+# tuple targets: positional consumption — array sources by index, keyed/
+# iterable sources in encounter order (classic maketuple semantics); members
+# lift through their own specs, construction via the same boxed-slot ccall
+# (tuple types are struct-shaped for jl_new_structv)
+function _spec_tuple(style::StructStyle, vs::ValueSpec, @nospecialize(v), name::String)
+    members = vs.child::Vector{ValueSpec}
+    n = length(members)
+    slots = Vector{Any}(undef, n)
+    i = 0
+    if v isa AbstractDict
+        for (_, ev) in v
+            i >= n && break
+            i += 1
+            slots[i] = _spec_nullwrap(style, @inbounds(members[i]), ev, name)
+        end
+    elseif (v isa AbstractVector && !(v isa AbstractVector{<:Pair})) || v isa Tuple
+        k = 0
+        for ev in v
+            k += 1
+            if i >= n
+                # surplus positional elements: the style's hook decides
+                # (default ignores, matching the classic tuple closure)
+                unknownfield(style, vs.ft::DataType, k, ev)
+                continue
+            end
+            i += 1
+            slots[i] = _spec_nullwrap(style, @inbounds(members[i]), ev, name)
+        end
+    else
+        # exotic source: the retained container machinery owns it (calling
+        # `make` here would re-enter _interp_root on the same spec — a loop);
+        # trim fails loudly — its folded container path can't drive this shape
+        TRIM_BUILD && _liftfail(vs.kind, name)
+        x, _ = maketuple(style, vs.declft, v)
+        return x
+    end
+    i == n || _missingfield(name, vs.ft::DataType)
+    GC.@preserve slots begin
+        return ccall(:jl_new_structv, Any, (Any, Ptr{Any}, UInt32), vs.ft, pointer(slots), n % UInt32)
+    end
+end
+
+# multidim / fixed-size arrays from nested source vectors: discover the
+# dimensions from nesting depth and lengths (innermost length is dim 1),
+# flatten in column-major order, and build through the style's
+# arrayfromdata hook (which the StaticArrays extension also implements)
+function _spec_fixedarray(style::StructStyle, vs::ValueSpec, @nospecialize(v), name::String)
+    v isa AbstractVector || begin
+        TRIM_BUILD && _liftfail(vs.kind, name)
+        x, _ = makearray(style, vs.declft, v)
+        return x
+    end
+    dims = Int[]
+    probe = v
+    while probe isa AbstractVector
+        pushfirst!(dims, length(probe))
+        probe = isempty(probe) ? nothing : probe[1]
+    end
+    el = vs.child::ValueSpec
+    data = Vector{Any}()
+    _flatten_colmajor!(data, v, length(dims))
+    lifted = _alloc_vector(el.declft, length(data))
+    for j = 1:length(data)
+        _setvec!(lifted, j, _spec_nullwrap(style, el, @inbounds(data[j]), name))
+    end
+    return arrayfromdata(vs.ft, lifted, Tuple(dims))
+end
+
+function _flatten_colmajor!(data::Vector{Any}, @nospecialize(v), depth::Int)
+    if depth <= 0 || !(v isa AbstractVector)
+        push!(data, v)
+        return nothing
+    end
+    for ev in v
+        _flatten_colmajor!(data, ev, depth - 1)
+    end
+    return nothing
 end
 
 function _liftdictkey(style::StructStyle, vs::ValueSpec, @nospecialize(dk), name::String)
@@ -1055,9 +1285,23 @@ end
 # true when `source` is a tree shape the interpreter drives directly; under
 # trim only AbstractDict (the Vector{Pair} applyeach dispatch is ambiguous
 # between the Pair-vector and AbstractArray methods for the verifier)
+"""
+    StructUtils.interpsource(source) -> Bool
+
+`true` (the default) when `source` may be driven through the tier-0
+interpreter. Formats with lazy source types that carry their own `lift`
+protocols (e.g. JSON's `LazyValue`) overload this to `false`, keeping those
+sources on their format-owned descent.
+"""
+interpsource(@nospecialize(source)) = true
+
+# JIT: the interpreter drives any source applyeach understands unless the
+# source type opts out (trees get concrete fast arms in _interp_make;
+# everything else takes the dynamic applyeach arm). Trim keeps the
+# concrete-dict contract; non-tree sources route to the hot descent at the
+# dispatcher.
 _interpsource(@nospecialize(source)) =
-    TRIM_BUILD ? source isa AbstractDict :
-    (source isa AbstractDict || source isa AbstractVector{<:Pair})
+    TRIM_BUILD ? source isa AbstractDict : interpsource(source)
 
 # entry: returns (value, state) like every `make`. Both the target type and
 # the source are inference-erased (one instance per style, ever — the
@@ -1066,14 +1310,29 @@ _interpsource(@nospecialize(source)) =
 # under JIT (specializing on source here invites invalidation-recompile
 # blowups when extensions load mid-session)
 Base.@nospecializeinfer function _interp_make(style::StructStyle, @nospecialize(T::Type), @nospecialize(source))
+    if !(T isa DataType)
+        # incomplete parametric targets can't table; the specialized descent
+        # keeps generic semantics — NOT `make`: the make/_interp_make
+        # inference cycle sends constprop into a never-terminating compile.
+        # The assert keeps _interp_make's return type a Tuple so concrete
+        # call-site destructures stay statically resolvable (trim fails
+        # loudly at parse time).
+        TRIM_BUILD && _liftfail(KIND_STRUCT, string(T))
+        return _hot_make3(style, T, source)::Tuple{Any,Any}
+    end
     tbl = fieldtable(T, style)
     if !tbl.eligible
-        # trim recursion into an ineligible type fails loudly at parse time;
-        # under JIT the dispatcher gate prevents reaching here, but fall back
-        # to the generic path for robustness
+        # tables the interpreter can't drive (mutables without @noarg
+        # registration, thunked defaults with no thunk): the specialized
+        # descent owns them, same shape as the non-DataType arm above
         TRIM_BUILD && _liftfail(KIND_STRUCT, String(nameof(tbl.T)))
-        return make(style, T, source)
+        return _hot_make3(style, T, source)::Tuple{Any,Any}
     end
+    return _interp_make(style, tbl, source)
+end
+
+# table-based core: the drive + construction (one instance per style)
+Base.@nospecializeinfer function _interp_make(style::StructStyle, tbl::FieldTable, @nospecialize(source))
     slots = Vector{Any}(undef, length(tbl.specs))
     f = InterpClosure(style, tbl, slots)
     st = if source isa Dict{String,Any}
@@ -1085,17 +1344,69 @@ Base.@nospecializeinfer function _interp_make(style::StructStyle, @nospecialize(
     else
         _liftfail(KIND_STRUCT, String(nameof(tbl.T)))
     end
-    # match makestruct: EarlyReturn from a custom unknownfield flows through
+    # EarlyReturn from a custom unknownfield flows through
     # as state; construction still happens
     return _construct_interp(style, tbl, slots, source), st
 end
 
-# gate consulted from `make`'s structlike arm: interpret when the target has
-# an eligible table and the source is tree-shaped
-function _interpready(style::StructStyle, @nospecialize(T::Type), @nospecialize(source))
-    T isa DataType || return false
-    _interpsource(source) || return false
-    return fieldtable(T, style).eligible
+# root ValueSpec for a non-struct target (Vector, Dict, Set, Tuple, Matrix,
+# or unions thereof): built once per (target, style type), same store
+function rootspec(@nospecialize(T::Type), style::StructStyle)
+    styletype = typeof(style)
+    snap = @atomic METASTORE.snap
+    entry = get(snap.roots, T, nothing)
+    if entry !== nothing
+        for (st, vs) in entry
+            st === styletype && return vs::ValueSpec
+        end
+    end
+    vs = valuespec(snap, style, T, false, nothing)
+    lock(META_LOCK)
+    try
+        old = @atomic METASTORE.snap
+        roots = copy(old.roots)
+        v = get(roots, T, nothing)
+        v = v === nothing ? Vector{Pair{DataType,Any}}() : copy(v)
+        any(p -> first(p) === styletype, v) || push!(v, styletype => vs)
+        roots[T] = v
+        @atomic METASTORE.snap = MetaSnap(old.raw, roots, old.tables)
+    finally
+        unlock(META_LOCK)
+    end
+    return vs
+end
+
+# entry for non-struct targets: run the spec tree over the source and wrap
+# in the (value, state) contract. @nospecializeinfer: the source-trait check
+# must stay a runtime verdict — folding `interpsource(::SomeLazy) = false`
+# at a dispatcher call site erases this arm and invites a pathological
+# constprop spiral through the mutually recursive make family (observed as
+# a never-terminating typed-parse compile in JSON's workload)
+Base.@nospecializeinfer function _interp_root(style::StructStyle, @nospecialize(T::Type), @nospecialize(source))
+    # lazy/positional format sources carry their own (value, pos) state
+    # contract: the retained container machinery owns them
+    _interpsource(source) || return nothing
+    vs = rootspec(T, style)
+    if vs.kind == KIND_CUSTOM || vs.kind == KIND_UNSUPPORTED
+        # a target the spec tree can't describe (custom AbstractDict
+        # subtypes, exotic arraylikes): decline — the dispatcher's container
+        # arms own it
+        return nothing
+    end
+    return _spec_nullwrap(style, vs, source, "root"), defaultstate(style)
+end
+
+# gate consulted from `make`'s structlike arm under JIT: returns the built
+# field table when the target is eligible and the source tree-shaped, else
+# nothing. Returning the table (rather than a Bool) lets the dispatcher hand
+# it straight to the interpreter — volatile tables rebuild on every
+# `fieldtable` call, and a second build would double-fire stateful
+# fieldtags/fielddefaults hooks
+function _interptable(style::StructStyle, @nospecialize(T::Type), @nospecialize(source))
+    T isa DataType || return nothing
+    _interpsource(source) || return nothing
+    tbl = fieldtable(T, style)
+    return tbl.eligible ? tbl : nothing
 end
 
 """
@@ -1107,35 +1418,3 @@ end
 interpready(style::StructStyle, @nospecialize(T::Type)) =
     T isa DataType && fieldtable(T, style).eligible
 
-"""
-    StructUtils.interptreesafe(style, T) -> Bool
-
-`true` when `T`'s field table — including nested struct and vector-element
-tables — contains no choosetype-tagged fields or abstract CUSTOM leaves.
-Those receive the raw source value in user functions, so formats that
-materialize an alternate tree representation for the interpreter (e.g. JSON
-parsing to `Object` instead of handing out lazy values) must keep such types
-on their classic path.
-"""
-interptreesafe(style::StructStyle, @nospecialize(T::Type)) =
-    _treesafe(style, T, Base.IdSet{Any}())
-
-function _treesafe(style::StructStyle, @nospecialize(T), seen::Base.IdSet{Any})::Bool
-    T in seen && return true
-    push!(seen, T)
-    T isa DataType || return true
-    tbl = fieldtable(T, style)
-    tbl.eligible || return true # routed classic anyway
-    tbl.treesafe || return false
-    for sp in tbl.specs
-        _spec_treesafe(style, sp.spec, seen) || return false
-    end
-    return true
-end
-
-function _spec_treesafe(style::StructStyle, vs::ValueSpec, seen::Base.IdSet{Any})::Bool
-    vs.kind == KIND_STRUCT && return _treesafe(style, vs.ft, seen)
-    vs.child isa ValueSpec && !_spec_treesafe(style, vs.child::ValueSpec, seen) && return false
-    vs.child2 isa ValueSpec && !_spec_treesafe(style, vs.child2::ValueSpec, seen) && return false
-    return true
-end

--- a/src/interp.jl
+++ b/src/interp.jl
@@ -502,7 +502,7 @@ function valuespec(snap::MetaSnap, style::StructStyle, @nospecialize(ft0), ignor
         # source-shape disambiguation only works when exactly ONE member is
         # array-like (arrays and sets, per the trait defaults) — with two
         # array-like members the choice would be ambiguous, so the union
-        # degrades to the generic arm (which errors, deliberately)
+        # degrades to the generic arm (which errors)
         arr_a = _shape_arraylike(a)
         arr_b = _shape_arraylike(b)
         if arr_a == arr_b
@@ -955,7 +955,7 @@ end
 
 # ---------------- the interpreter ----------------
 
-# per-(style, source) closure; deliberately NOT parameterized on the target
+# per-(style, source) closure; not parameterized on the target
 # type, so applyeach specializes once per source shape, never per struct
 struct InterpClosure{S<:StructStyle}
     style::S
@@ -1409,10 +1409,9 @@ end
 
 # entry for non-struct targets: run the spec tree over the source and wrap
 # in the (value, state) contract. The un-specialized arguments keep the
-# source check below a runtime decision: if the compiler could prove its
-# answer at a call site it would delete this arm, and compiling the
-# mutually recursive make functions with arms deleted has hung the
-# compiler outright
+# source check below a runtime decision the compiler cannot prove — the
+# make functions are mutually recursive, and constant folding through that
+# cycle does not terminate, so both routing arms must remain visible
 Base.@nospecializeinfer function _interp_root(style::StructStyle, @nospecialize(T::Type), @nospecialize(source))
     # lazy/positional format sources carry their own (value, pos) state
     # contract: the retained container machinery owns them

--- a/src/interp.jl
+++ b/src/interp.jl
@@ -615,6 +615,35 @@ catch
     false
 end
 
+# per-type memo of which FIELDS carry their own make methods, for the hot
+# closures (computed in the runtime world at first use, so hooks defined any
+# time before a type's first parse are honored — a generated function's
+# frozen world cannot see them). JIT-only: trim builds never consult it.
+mutable struct _CustomFieldsMemo
+    @atomic table::Dict{Type,Any} # UnionAll targets key here too (#54)
+end
+const _CUSTOM_FIELDS = _CustomFieldsMemo(Dict{Type,Any}())
+const _CUSTOM_FIELDS_LOCK = ReentrantLock()
+
+function _custom_make_fields(::Type{T}) where {T}
+    tbl = @atomic _CUSTOM_FIELDS.table
+    r = get(tbl, T, nothing)
+    r === nothing || return r::NTuple{fieldcount(T),Bool}
+    v = ntuple(i -> _has_custom_make(fieldtype(T, i)), fieldcount(T))
+    lock(_CUSTOM_FIELDS_LOCK)
+    try
+        old = @atomic _CUSTOM_FIELDS.table
+        if !haskey(old, T)
+            new = copy(old)
+            new[T] = v
+            @atomic _CUSTOM_FIELDS.table = new
+        end
+    finally
+        unlock(_CUSTOM_FIELDS_LOCK)
+    end
+    return v
+end
+
 _live_pertags(style::StructStyle, @nospecialize(T), fn::Symbol) = try
     fieldtags(style, T, fn)
 catch

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -113,6 +113,21 @@ function parsefields!(field_exprs::Vector{Any})
     return fields
 end
 
+# the expressions the `:hot` option appends after a struct definition;
+# shared with the standalone `StructUtils.@hot`
+function _hot_exprs(T, samples...)
+    return Any[
+        :(StructUtils.ishot(::Type{<:$T}) = true),
+        :(function StructUtils.make(style::StructUtils.StructStyle, ::Type{S}, source) where {S<:$T}
+            StructUtils._hot_entry(style, S, source)
+        end),
+        :(function StructUtils.make(style::StructUtils.StructStyle, ::Type{S}, source, tags) where {S<:$T}
+            StructUtils._hot_entry(style, S, source, tags)
+        end),
+        :(StructUtils._hot_precompile!($T, ($(samples...),))),
+    ]
+end
+
 # leading `:hot` option: `@kwarg :hot struct ...` opts the type into the
 # fully-specialized make tier + precompile-time compilation via hot hooks
 function _parse_macro_opts(kind::Symbol, args)
@@ -271,14 +286,7 @@ function parse_struct_def(kind, src, mod, expr; hot::Bool=false)
             Expr(:kw, :nonstruct, register_nonstruct), Expr(:kw, :valsdependent, valsdep)), T))
     if hot
         kind === :nonstruct && throw(ArgumentError("@nonstruct does not support :hot"))
-        push!(ret.args, :(StructUtils.ishot(::Type{<:$T}) = true))
-        push!(ret.args, :(function StructUtils.make(style::StructUtils.StructStyle, ::Type{S}, source) where {S<:$T}
-            StructUtils._hot_entry(style, S, source)
-        end))
-        push!(ret.args, :(function StructUtils.make(style::StructUtils.StructStyle, ::Type{S}, source, tags) where {S<:$T}
-            StructUtils._hot_entry(style, S, source, tags)
-        end))
-        push!(ret.args, :(StructUtils._hot_precompile!($T)))
+        append!(ret.args, _hot_exprs(T))
     end
     # Return the struct type for REPL friendliness (like Base.@kwdef)
     push!(ret.args, T)

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -267,7 +267,7 @@ function parse_struct_def(kind, src, mod, expr; hot::Bool=false)
         end
         generate_field_defaults_and_tags!(ret, T, fields, typeparam_names, typeparams)
     end
-    # register tier-0 interpreter metadata: defaults and tags as plain data,
+    # register interpreter metadata: defaults and tags as plain data,
     # so trimmed binaries (and the interpreter generally) never need per-type
     # method dispatch to resolve them
     fields_with_defaults = [f for f in fields if f.default !== none]

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -124,7 +124,7 @@ function _hot_exprs(T, samples...)
         :(function StructUtils.make(style::StructUtils.StructStyle, ::Type{S}, source, tags) where {S<:$T}
             StructUtils._hot_entry(style, S, source, tags)
         end),
-        :(StructUtils._hot_precompile!($T, ($(samples...),))),
+        :(StructUtils.hot_precompile!($T, ($(samples...),))),
     ]
 end
 

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -142,6 +142,7 @@ function parse_struct_def(kind, src, mod, expr)
     push!(ret.args, :($Base.@__doc__ $expr))
     # parse field exprs and sanitize field definitions
     fields = parsefields!(fieldsblock.args)
+    register_nonstruct = kind == :nonstruct
     if kind == :noarg
         ismutable || throw(ArgumentError("@noarg structs must be mutable"))
         if any(f.isconst for f in fields)
@@ -240,6 +241,23 @@ function parse_struct_def(kind, src, mod, expr)
         end
         generate_field_defaults_and_tags!(ret, T, fields, typeparam_names, typeparams)
     end
+    # register tier-0 interpreter metadata: defaults and tags as plain data,
+    # so trimmed binaries (and the interpreter generally) never need per-type
+    # method dispatch to resolve them
+    fields_with_defaults = [f for f in fields if f.default !== none]
+    defs_thunk = isempty(fields_with_defaults) ? :nothing :
+        Expr(:->, Expr(:tuple), _fielddefaults_body_2arg(fields_with_defaults))
+    # a default referencing another field must be computed against *parsed*
+    # values (the 3-arg fielddefaults semantics), not other defaults — those
+    # structs keep the vals-aware construct path
+    allnames = Symbol[f.name for f in fields]
+    valsdep = any(f.default !== none && _references_typeparam(f.default, allnames) for f in fields)
+    tagged = [f for f in fields if f.tags !== none]
+    tags_expr = isempty(tagged) ? :nothing :
+        Expr(:tuple, Expr(:parameters, [:($(f.name) = $(f.tags)) for f in tagged]...))
+    push!(ret.args, Expr(:call, GlobalRef(StructUtils, :register_fieldtable!),
+        Expr(:parameters, Expr(:kw, :defaults, defs_thunk), Expr(:kw, :tags, tags_expr),
+            Expr(:kw, :nonstruct, register_nonstruct), Expr(:kw, :valsdependent, valsdep)), T))
     # Return the struct type for REPL friendliness (like Base.@kwdef)
     push!(ret.args, T)
     return esc(ret)

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -113,7 +113,18 @@ function parsefields!(field_exprs::Vector{Any})
     return fields
 end
 
-function parse_struct_def(kind, src, mod, expr)
+# leading `:hot` option: `@kwarg :hot struct ...` opts the type into the
+# fully-specialized make tier + precompile-time compilation via hot hooks
+function _parse_macro_opts(kind::Symbol, args)
+    if length(args) == 1
+        return false, args[1]
+    elseif length(args) == 2 && args[1] isa QuoteNode && args[1].value === :hot
+        return true, args[2]
+    end
+    throw(ArgumentError("@$kind: expected `@$kind [:hot] struct ...`"))
+end
+
+function parse_struct_def(kind, src, mod, expr; hot::Bool=false)
     expr = macroexpand(mod, expr)
     Meta.isexpr(expr, :struct) || throw(ArgumentError("Invalid usage of @$kind macro"))
     # kind is: :noarg, :kwarg, :defaults, :tags
@@ -258,6 +269,17 @@ function parse_struct_def(kind, src, mod, expr)
     push!(ret.args, Expr(:call, GlobalRef(StructUtils, :register_fieldtable!),
         Expr(:parameters, Expr(:kw, :defaults, defs_thunk), Expr(:kw, :tags, tags_expr),
             Expr(:kw, :nonstruct, register_nonstruct), Expr(:kw, :valsdependent, valsdep)), T))
+    if hot
+        kind === :nonstruct && throw(ArgumentError("@nonstruct does not support :hot"))
+        push!(ret.args, :(StructUtils.ishot(::Type{<:$T}) = true))
+        push!(ret.args, :(function StructUtils.make(style::StructUtils.StructStyle, ::Type{S}, source) where {S<:$T}
+            StructUtils._hot_entry(style, S, source)
+        end))
+        push!(ret.args, :(function StructUtils.make(style::StructUtils.StructStyle, ::Type{S}, source, tags) where {S<:$T}
+            StructUtils._hot_entry(style, S, source, tags)
+        end))
+        push!(ret.args, :(StructUtils._hot_precompile!($T)))
+    end
     # Return the struct type for REPL friendliness (like Base.@kwdef)
     push!(ret.args, T)
     return esc(ret)
@@ -419,8 +441,9 @@ function Foo()
 end
 ```
 """
-macro noarg(expr)
-    parse_struct_def(:noarg, __source__, __module__, expr)
+macro noarg(args...)
+    hot, expr = _parse_macro_opts(:noarg, args)
+    parse_struct_def(:noarg, __source__, __module__, expr; hot)
 end
 
 """
@@ -453,8 +476,9 @@ function Foo(; a, b="foo", c=1.0, d=[1, 2, 3])
 end
 ```
 """
-macro kwarg(expr)
-    parse_struct_def(:kwarg, __source__, __module__, expr)
+macro kwarg(args...)
+    hot, expr = _parse_macro_opts(:kwarg, args)
+    parse_struct_def(:kwarg, __source__, __module__, expr; hot)
 end
 
 """
@@ -487,8 +511,9 @@ function Foo(a)
 end
 ```
 """
-macro defaults(expr)
-    parse_struct_def(:defaults, __source__, __module__, expr)
+macro defaults(args...)
+    hot, expr = _parse_macro_opts(:defaults, args)
+    parse_struct_def(:defaults, __source__, __module__, expr; hot)
 end
 
 """
@@ -501,8 +526,9 @@ specified for each field.
 
 $SHARED_MACRO_DOCS
 """
-macro tags(expr)
-    parse_struct_def(:tags, __source__, __module__, expr)
+macro tags(args...)
+    hot, expr = _parse_macro_opts(:tags, args)
+    parse_struct_def(:tags, __source__, __module__, expr; hot)
 end
 
 """
@@ -537,6 +563,7 @@ end
 x = StructUtils.make(MyUnit, "hello")
 ```
 """
-macro nonstruct(expr)
-    parse_struct_def(:nonstruct, __source__, __module__, expr)
+macro nonstruct(args...)
+    hot, expr = _parse_macro_opts(:nonstruct, args)
+    parse_struct_def(:nonstruct, __source__, __module__, expr; hot)
 end

--- a/test/hot.jl
+++ b/test/hot.jl
@@ -1,0 +1,91 @@
+using Test, Dates, UUIDs, StructUtils
+
+# :hot tier: emitted specialized methods, tree-gate routing, hooks
+
+@kwarg struct HTier
+    name::String
+    amount::Int = 0
+    currency::String = "usd"
+end
+
+@kwarg :hot struct HotTier
+    name::String
+    amount::Int = 0
+    currency::String = "usd"
+end
+
+@kwarg :hot struct HotEvent
+    name::String
+    day::Date = Date(0)
+    cap::Union{Int,Nothing} = nothing
+    venue::Union{HotTier,Nothing} = nothing
+    tiers::Vector{HotTier} = HotTier[]
+end
+
+@noarg :hot mutable struct HotMut
+    a::Int = 0
+    b::String = ""
+end
+
+struct HPlain
+    x::Int
+end
+StructUtils.@hot HPlain
+
+@testset ":hot tier" begin
+    @test StructUtils.ishot(HotTier)
+    @test !StructUtils.ishot(HTier)
+    @test StructUtils.ishot(HPlain)
+
+    # differential: hot vs non-hot twin from identical tree sources
+    srcd = Dict{String,Any}("name" => "a", "amount" => 2)
+    hot = StructUtils.make(HotTier, srcd)
+    plain = StructUtils.make(HTier, srcd)
+    @test hot.name == plain.name == "a"
+    @test hot.amount == plain.amount == 2
+    @test hot.currency == plain.currency == "usd"
+
+    # NamedTuple source takes the hot descent
+    nt = StructUtils.make(HotTier, (name="n", amount=3, currency="eur"))
+    @test nt.name == "n" && nt.amount == 3 && nt.currency == "eur"
+
+    # nested structs + vectors from NamedTuple sources
+    ev = StructUtils.make(HotEvent, (name="e", day=Date(2026, 1, 2), venue=(name="v",),
+        tiers=[(name="t1",), (name="t2", amount=5)]))
+    @test ev.venue isa HotTier && ev.venue.name == "v" && ev.venue.currency == "usd"
+    @test length(ev.tiers) == 2 && ev.tiers[2].amount == 5
+    @test ev.day == Date(2026, 1, 2)
+    @test ev.cap === nothing
+
+    # tree sources route through the interpreter with identical results
+    ev2 = StructUtils.make(HotEvent, Dict{String,Any}("name" => "e2",
+        "tiers" => Any[Dict{String,Any}("name" => "x")]))
+    @test ev2.tiers[1].currency == "usd"
+    @test ev2.venue === nothing
+
+    # @noarg :hot mutable
+    hm = StructUtils.make(HotMut, (a=1, b="z"))
+    @test hm.a == 1 && hm.b == "z"
+
+    # standalone @hot on a plain (non-macro) struct
+    @test StructUtils.make(HPlain, (x=7,)).x == 7
+    @test StructUtils.make(HPlain, Dict{String,Any}("x" => 8)).x == 8
+
+    # hook registry fires per annotated type under force
+    fired = Ref(0)
+    hook = (T, samples) -> (fired[] += 1; nothing)
+    StructUtils.register_hot_hook!(hook)
+    try
+        StructUtils._hot_precompile!(HotTier; force=true)
+        @test fired[] == 1
+        StructUtils._hot_precompile!(HotEvent, ("{}",); force=true)
+        @test fired[] == 2
+    finally
+        pop!(StructUtils.HOT_HOOKS)
+    end
+
+    # :nonstruct rejects :hot
+    @test_throws LoadError @eval @nonstruct :hot struct HotNon
+        x::Int
+    end
+end

--- a/test/hot.jl
+++ b/test/hot.jl
@@ -76,9 +76,9 @@ StructUtils.@hot HPlain
     hook = (T, samples) -> (fired[] += 1; nothing)
     StructUtils.register_hot_hook!(hook)
     try
-        StructUtils._hot_precompile!(HotTier; force=true)
+        StructUtils.hot_precompile!(HotTier; force=true)
         @test fired[] == 1
-        StructUtils._hot_precompile!(HotEvent, ("{}",); force=true)
+        StructUtils.hot_precompile!(HotEvent, ("{}",); force=true)
         @test fired[] == 2
     finally
         pop!(StructUtils.HOT_HOOKS)

--- a/test/hot_trim_safe.jl
+++ b/test/hot_trim_safe.jl
@@ -1,0 +1,53 @@
+# :hot tier trim workload: compiled with `juliac --trim=safe` in the plain
+# (no-preference) env — the emitted specialized descent is statically
+# resolvable on its own for non-tree sources (NamedTuples here; format lazy
+# values in practice).
+#
+# Field/value shapes are limited to the cross-product-proven set (Int,
+# String, NamedTuple, Vector): the hot findfield keeps every (field ×
+# value-type) arm alive for runtime-keyed sources, so scalar types whose
+# wrong-type lifts have interior machinery (dates) belong to format-side
+# workloads where the source value type is uniform. Tree-shaped sources are
+# exercised by interp_trim_safe.jl under the trim_build preference instead.
+using StructUtils
+
+@kwarg :hot struct HTTier
+    name::String
+    amount::Int = 0
+    currency::String = "usd"
+end
+
+@kwarg :hot struct HTEvent
+    name::String
+    cap::Union{Int,Nothing} = nothing
+    venue::Union{HTTier,Nothing} = nothing
+    tiers::Vector{HTTier} = HTTier[]
+end
+
+function run_hot_trim_sample()
+    ev = StructUtils.make(HTEvent, (name="e", cap=4,
+        venue=(name="v", amount=1), tiers=[(name="a", amount=0), (name="b", amount=5)]))
+    ev isa HTEvent || error("type")
+    e = ev::HTEvent
+    e.name == "e" || error("name")
+    e.cap == 4 || error("cap")
+    v = e.venue
+    v isa HTTier || error("venue")
+    (v::HTTier).amount == 1 || error("venue amount")
+    length(e.tiers) == 2 || error("tiers")
+    e.tiers[1].currency == "usd" || error("cur default")
+    e.tiers[2].amount == 5 || error("amount")
+    ev2 = StructUtils.make(HTEvent, (name="x",))
+    (ev2::HTEvent).cap === nothing || error("cap nothing")
+    isempty((ev2::HTEvent).tiers) || error("tiers default")
+    return nothing
+end
+
+function @main(args::Vector{String})::Cint
+    _ = args
+    run_hot_trim_sample()
+    Core.println("HOT_TRIM_OK")
+    return 0
+end
+
+Base.Experimental.entrypoint(main, (Vector{String},))

--- a/test/interp.jl
+++ b/test/interp.jl
@@ -1,7 +1,7 @@
 using Test, Dates, UUIDs, StructUtils
 
 # tier-0 interpreter unit tests: table resolution, closed-kind lifting,
-# defaults policies, and routing between the interpreter and the classic path
+# defaults policies, and full-coverage eligibility of the interpreter
 
 struct ITagStyle <: StructUtils.StructStyle end
 StructUtils.fieldtagkey(::ITagStyle) = :itag
@@ -132,21 +132,22 @@ const IEVENT_SRC = Dict{String,Any}(
         @test_throws ArgumentError StructUtils.make(ITier, Dict{String,Any}("amount" => 1))
     end
 
-    @testset "routing to the classic path" begin
-        # unregistered plain struct: classic path, still works from a Dict
+    @testset "full interpreter coverage" begin
+        # unregistered plain struct: interpreter-handled from a Dict
         @test StructUtils.make(IPlain, Dict("x" => 1, "y" => "z")) == IPlain(1, "z")
-        @test !StructUtils.fieldtable(IPlain, StructUtils.DefaultStyle()).eligible
-        # manual fielddefaults overload (no macro): classic path honors it
+        @test StructUtils.fieldtable(IPlain, StructUtils.DefaultStyle()).eligible
+        # manual fielddefaults overload (no macro): volatile table honors it
         @test StructUtils.make(IManual, Dict{String,Any}()).m == 42
-        @test !StructUtils.fieldtable(IManual, StructUtils.DefaultStyle()).eligible
-        # stateful per-style fieldtags: classic path, called once per make
+        @test StructUtils.fieldtable(IManual, StructUtils.DefaultStyle()).eligible
+        # stateful per-style fieldtags: volatile table rebuilds per make so
+        # the hook keeps its call-per-make semantics
         cst = ICountStyle(0)
         StructUtils.make(cst, ICounted, Dict("c" => 1))
         StructUtils.make(cst, ICounted, Dict("c" => 2))
         @test cst.calls >= 2
-        @test !StructUtils.fieldtable(ICounted, cst).eligible
-        # tuple alias name tags: interpreter-handled (alias match candidates
-        # in the field spec), both aliases match
+        @test StructUtils.fieldtable(ICounted, cst).volatile
+        # tuple alias name tags: alias match candidates in the field spec,
+        # both aliases match
         @test StructUtils.make(IAliased, Dict("value" => 7)).v == 7
         @test StructUtils.make(IAliased, Dict("v" => 8)).v == 8
         @test StructUtils.fieldtable(IAliased, StructUtils.DefaultStyle()).eligible
@@ -168,7 +169,7 @@ const IEVENT_SRC = Dict{String,Any}(
     end
 end
 
-# expanded interpreter coverage: shapes that previously routed classic
+# expanded interpreter coverage: shapes beyond plain field structs
 @kwarg struct IWide
     nv::Vector{Union{Int,Nothing}} = Union{Int,Nothing}[]
     mv::Vector{Union{String,Missing}} = Union{String,Missing}[]

--- a/test/interp.jl
+++ b/test/interp.jl
@@ -1,0 +1,168 @@
+using Test, Dates, UUIDs, StructUtils
+
+# tier-0 interpreter unit tests: table resolution, closed-kind lifting,
+# defaults policies, and routing between the interpreter and the classic path
+
+struct ITagStyle <: StructUtils.StructStyle end
+StructUtils.fieldtagkey(::ITagStyle) = :itag
+
+mutable struct ICountStyle <: StructUtils.StructStyle
+    calls::Int
+end
+
+struct IStrictStyle <: StructUtils.StructStyle end
+struct IUnknownFieldError <: Exception
+    key::Any
+end
+StructUtils.unknownfield(::IStrictStyle, ::Type{T}, key, value) where {T} =
+    throw(IUnknownFieldError(key))
+
+@kwarg struct ITier
+    name::String
+    amount::Int = 0
+    currency::String = "usd"
+end
+
+@kwarg struct ILoc
+    label::String = ""
+    lat::Union{Float64,Nothing} = nothing
+    tags::Vector{Symbol} = Symbol[]
+end
+
+@kwarg struct IEvent
+    name::String
+    day::Date = Date(0)
+    at::Union{DateTime,Nothing} = nothing
+    uid::Union{UUID,Nothing} = nothing
+    cap::Union{Int,Nothing} = nothing
+    kind::Symbol = :none &(itag=(name="event_kind",),)
+    venue::Union{ILoc,Nothing} = nothing
+    tiers::Vector{ITier} = ITier[]
+    seed::Vector{Int} = [1, 2, 3]
+    note::Any = nothing
+    score::Union{Float64,Missing} = missing
+end
+
+@kwarg struct IComputed
+    a::Int
+    b::Int = a + 10
+end
+
+@nonstruct struct IPoint
+    x::Int
+    y::Int
+end
+StructUtils.lift(::Type{IPoint}, s::String) =
+    (p = split(s, ','); IPoint(parse(Int, p[1]), parse(Int, p[2])))
+
+@kwarg struct IHasPoint
+    p::IPoint = IPoint(0, 0)
+end
+
+struct IPlain
+    x::Int
+    y::String
+end
+
+struct IManual
+    m::Int
+end
+StructUtils.fielddefaults(::StructUtils.StructStyle, ::Type{IManual}) = (m=42,)
+
+struct ICounted
+    c::Int
+end
+function StructUtils.fieldtags(st::ICountStyle, ::Type{ICounted})
+    st.calls += 1
+    return (c=(name="c",),)
+end
+
+@kwarg struct IAliased
+    v::Int = 0 &(name=("v", "value"),)
+end
+
+const IEVENT_SRC = Dict{String,Any}(
+    "name" => "Kickoff",
+    "day" => "2026-08-01",
+    "at" => "2026-07-25T23:59:59",
+    "uid" => "c8b1cf79-de6a-54ab-a142-682c06a0de6a",
+    "cap" => 64,
+    "kind" => "league",
+    "venue" => Dict{String,Any}("label" => "Gym", "lat" => 40.1, "tags" => Any["indoor"]),
+    "tiers" => Any[
+        Dict{String,Any}("name" => "Early", "amount" => 2500, "currency" => "eur"),
+        Dict{String,Any}("name" => "Late"),
+    ],
+    "note" => Dict{String,Any}("k" => "v"),
+    "score" => nothing,
+    "unknown_extra" => Any[1, 2, 3],
+)
+
+@testset "tier-0 interpreter" begin
+    @testset "closed-kind correctness" begin
+        ev = StructUtils.make(IEvent, IEVENT_SRC)
+        @test ev.name == "Kickoff"
+        @test ev.day == Date(2026, 8, 1)
+        @test ev.at == DateTime(2026, 7, 25, 23, 59, 59)
+        @test ev.uid == UUID("c8b1cf79-de6a-54ab-a142-682c06a0de6a")
+        @test ev.cap == 64
+        @test ev.kind === :league
+        @test ev.venue isa ILoc && ev.venue.lat == 40.1 && ev.venue.tags == [:indoor]
+        @test length(ev.tiers) == 2
+        @test ev.tiers[1].currency == "eur"
+        @test ev.tiers[2].currency == "usd" # per-field default
+        @test ev.note isa Dict{String,Any}
+        @test ev.score === missing
+        @test StructUtils.fieldtable(IEvent, StructUtils.DefaultStyle()).eligible
+        # Symbol keys and Vector{Pair} sources
+        @test StructUtils.make(ITier, Dict(:name => "s", :amount => 5)).amount == 5
+        @test StructUtils.make(ITier, ["name" => "vp"]).currency == "usd"
+    end
+
+    @testset "defaults policies" begin
+        a = StructUtils.make(IEvent, Dict{String,Any}("name" => "a"))
+        b = StructUtils.make(IEvent, Dict{String,Any}("name" => "b"))
+        @test a.tiers !== b.tiers          # FRESHEMPTY re-materialized
+        @test a.seed == [1, 2, 3] && a.seed !== b.seed  # thunk default not aliased
+        @test a.venue === nothing && a.cap === nothing && a.score === missing
+        # vals-dependent defaults compute against parsed values
+        @test StructUtils.make(IComputed, Dict("a" => 5)).b == 15
+        @test StructUtils.make(IComputed, Dict("a" => 5, "b" => 1)).b == 1
+        # missing required field
+        @test_throws ArgumentError StructUtils.make(ITier, Dict{String,Any}("amount" => 1))
+    end
+
+    @testset "routing to the classic path" begin
+        # unregistered plain struct: classic path, still works from a Dict
+        @test StructUtils.make(IPlain, Dict("x" => 1, "y" => "z")) == IPlain(1, "z")
+        @test !StructUtils.fieldtable(IPlain, StructUtils.DefaultStyle()).eligible
+        # manual fielddefaults overload (no macro): classic path honors it
+        @test StructUtils.make(IManual, Dict{String,Any}()).m == 42
+        @test !StructUtils.fieldtable(IManual, StructUtils.DefaultStyle()).eligible
+        # stateful per-style fieldtags: classic path, called once per make
+        cst = ICountStyle(0)
+        StructUtils.make(cst, ICounted, Dict("c" => 1))
+        StructUtils.make(cst, ICounted, Dict("c" => 2))
+        @test cst.calls >= 2
+        @test !StructUtils.fieldtable(ICounted, cst).eligible
+        # tuple alias name tags: classic path, both aliases match
+        @test StructUtils.make(IAliased, Dict("value" => 7)).v == 7
+        @test StructUtils.make(IAliased, Dict("v" => 8)).v == 8
+        @test !StructUtils.fieldtable(IAliased, StructUtils.DefaultStyle()).eligible
+        # @nonstruct nested field lifts, never field-parses
+        @test StructUtils.make(IHasPoint, Dict("p" => "3,4")).p == IPoint(3, 4)
+    end
+
+    @testset "tagkey namespacing and styles" begin
+        # ITagStyle resolves the :itag namespace: rename applies
+        ev = StructUtils.make(ITagStyle(), IEvent, Dict{String,Any}("name" => "x", "event_kind" => "k"))
+        @test ev[1].kind === :k
+        # DefaultStyle has no tagkey: the :itag-namespaced rename does NOT
+        # apply, so "event_kind" is an unknown key and the default holds
+        ev2 = StructUtils.make(IEvent, Dict{String,Any}("name" => "x", "event_kind" => "k2"))
+        @test ev2.kind === :none
+        # unknownfield hook fires for unmatched keys
+        @test_throws IUnknownFieldError StructUtils.make(IStrictStyle(), ITier,
+            Dict{String,Any}("name" => "t", "bogus" => 1))
+    end
+end

--- a/test/interp.jl
+++ b/test/interp.jl
@@ -145,10 +145,11 @@ const IEVENT_SRC = Dict{String,Any}(
         StructUtils.make(cst, ICounted, Dict("c" => 2))
         @test cst.calls >= 2
         @test !StructUtils.fieldtable(ICounted, cst).eligible
-        # tuple alias name tags: classic path, both aliases match
+        # tuple alias name tags: interpreter-handled (alias match candidates
+        # in the field spec), both aliases match
         @test StructUtils.make(IAliased, Dict("value" => 7)).v == 7
         @test StructUtils.make(IAliased, Dict("v" => 8)).v == 8
-        @test !StructUtils.fieldtable(IAliased, StructUtils.DefaultStyle()).eligible
+        @test StructUtils.fieldtable(IAliased, StructUtils.DefaultStyle()).eligible
         # @nonstruct nested field lifts, never field-parses
         @test StructUtils.make(IHasPoint, Dict("p" => "3,4")).p == IPoint(3, 4)
     end
@@ -165,4 +166,72 @@ const IEVENT_SRC = Dict{String,Any}(
         @test_throws IUnknownFieldError StructUtils.make(IStrictStyle(), ITier,
             Dict{String,Any}("name" => "t", "bogus" => 1))
     end
+end
+
+# expanded interpreter coverage: shapes that previously routed classic
+@kwarg struct IWide
+    nv::Vector{Union{Int,Nothing}} = Union{Int,Nothing}[]
+    mv::Vector{Union{String,Missing}} = Union{String,Missing}[]
+    nested::Vector{Vector{Int}} = Vector{Int}[]
+    d::Dict{String,Int} = Dict{String,Int}()
+    dany::Dict{String,Any} = Dict{String,Any}()
+    dsym::Dict{Symbol,String} = Dict{Symbol,String}()
+    u::Union{String,Vector{String}} = ""
+    s::Set{Int} = Set{Int}()
+    alias::Int = 0 &(name=("alias", "alias2"),)
+end
+
+@noarg mutable struct IMutT
+    a::Int = 3
+    b::Union{String,Nothing} = nothing
+    c::Vector{Float64} = Float64[]
+end
+
+@kwarg struct IParam{N}
+    a::Int = 0
+    b::NTuple{N,Int} = ntuple(_ -> 0, N)
+end
+
+@testset "tier-0 expanded coverage" begin
+    st = StructUtils.DefaultStyle()
+    src = Dict{String,Any}(
+        "nv" => Any[1, nothing, 3],
+        "mv" => Any["x", nothing],
+        "nested" => Any[Any[1, 2], Any[3]],
+        "d" => Dict{String,Any}("k" => 2),
+        "dany" => Dict{String,Any}("k" => Any[1]),
+        "dsym" => Dict{String,Any}("s" => "v"),
+        "u" => Any["p", "q"],
+        "s" => Any[1, 2, 2],
+        "alias2" => 9,
+    )
+    w = StructUtils.make(IWide, src)
+    @test w.nv == [1, nothing, 3]
+    @test isequal(w.mv, ["x", missing])
+    @test w.nested == [[1, 2], [3]]
+    @test w.d == Dict("k" => 2) && w.d isa Dict{String,Int}
+    @test w.dany["k"] == [1]
+    @test w.dsym == Dict(:s => "v")
+    @test w.u == ["p", "q"]
+    @test StructUtils.make(IWide, Dict{String,Any}("u" => "solo")).u == "solo"
+    @test w.s == Set([1, 2])
+    @test w.alias == 9
+    @test StructUtils.make(IWide, Dict{String,Any}("alias" => 4)).alias == 4
+    @test StructUtils.fieldtable(IWide, st).eligible
+
+    # @noarg mutable targets through the interpreter
+    m = StructUtils.make(IMutT, Dict{String,Any}("b" => "z"))
+    @test m.a == 3 && m.b == "z" && isempty(m.c)
+    @test StructUtils.fieldtable(IMutT, st).eligible
+    m2 = StructUtils.make(IMutT, Dict{String,Any}("a" => 1))
+    @test m2.c !== m.c
+
+    # NamedTuple targets, registration-free
+    nt = StructUtils.make(@NamedTuple{p::Int, q::Union{String,Nothing}}, Dict{String,Any}("p" => 1))
+    @test nt == (p = 1, q = nothing)
+
+    # parametric type-param-dependent defaults use the 3-arg path
+    pd = StructUtils.make(IParam{2}, Dict{String,Any}("a" => 5))
+    @test pd.a == 5 && pd.b == (0, 0)
+    @test StructUtils.fieldtable(IParam{2}, st).eligible
 end

--- a/test/interp_trim_safe.jl
+++ b/test/interp_trim_safe.jl
@@ -1,0 +1,133 @@
+# tier-0 interpreter trim workload: compiled by trim_compile_tests.jl with
+# `juliac --trim=safe` in an env whose LocalPreferences sets
+# [StructUtils] trim_build = true. Exercises the closed kind universe,
+# registered metadata (macro-emitted), reflection-only tables, defaults
+# policies, and error paths — all through the non-specializing interpreter.
+using StructUtils, Dates, UUIDs
+
+@kwarg struct TTier
+    name::String
+    amount::Int = 0
+    currency::String = "usd"
+end
+
+@kwarg struct TLoc
+    label::String = ""
+    lat::Union{Float64,Nothing} = nothing
+    tags::Vector{Symbol} = Symbol[]
+end
+
+@kwarg struct TEvent
+    name::String
+    day::Date = Date(0)
+    at::Union{DateTime,Nothing} = nothing
+    uid::Union{UUID,Nothing} = nothing
+    cap::Union{Int,Nothing} = nothing
+    kind::Symbol = :none
+    venue::Union{TLoc,Nothing} = nothing
+    tiers::Vector{TTier} = TTier[]
+    locs::Vector{TLoc} = TLoc[]
+    score::Union{Float64,Missing} = missing
+end
+
+struct TPlain
+    x::Int
+    y::String
+end
+
+struct TInts
+    a::Int
+    b::Int
+end
+
+function run_interp_trim_sample()
+    # trees are built with per-key setindex! (concrete key/value types):
+    # heterogeneous Dict pair-splat constructors are themselves not
+    # trim-verifiable, and real trimmed apps receive trees from a parser
+    venue = Dict{String,Any}()
+    venue["label"] = "Gym"
+    venue["lat"] = 40.1
+    venue["tags"] = Any["indoor"]
+    tier1 = Dict{String,Any}()
+    tier1["name"] = "Early"
+    tier1["amount"] = 2500
+    tier1["currency"] = "eur"
+    tier2 = Dict{String,Any}()
+    tier2["name"] = "Late"
+    src = Dict{String,Any}()
+    src["name"] = "Kickoff"
+    src["day"] = "2026-08-01"
+    src["at"] = "2026-07-25T23:59:59"
+    src["uid"] = "c8b1cf79-de6a-54ab-a142-682c06a0de6a"
+    src["cap"] = 64
+    src["kind"] = "league"
+    src["venue"] = venue
+    src["tiers"] = Any[tier1, tier2]
+    src["unknown_extra"] = Any[1, 2, 3]
+    ev = StructUtils.make(TEvent, src)
+    ev isa TEvent || error("TEvent type")
+    e = ev::TEvent
+    e.name == "Kickoff" || error("name")
+    e.day == Date(2026, 8, 1) || error("day")
+    e.at == DateTime(2026, 7, 25, 23, 59, 59) || error("at")
+    e.uid == UUID("c8b1cf79-de6a-54ab-a142-682c06a0de6a") || error("uid")
+    e.cap == 64 || error("cap")
+    e.kind === :league || error("kind")
+    v = e.venue
+    v isa TLoc || error("venue")
+    (v::TLoc).lat == 40.1 || error("lat")
+    (v::TLoc).tags == [:indoor] || error("tags")
+    length(e.tiers) == 2 || error("tiers")
+    e.tiers[1].currency == "eur" || error("cur1")
+    e.tiers[2].currency == "usd" || error("cur2")
+    isempty(e.locs) || error("locs")
+    e.score === missing || error("score")
+    # fresh-empty defaults never alias
+    minimal = Dict{String,Any}()
+    minimal["name"] = "b"
+    e2 = StructUtils.make(TEvent, minimal)
+    (e2::TEvent).tiers === e.tiers && error("alias")
+    # Symbol-keyed source
+    symsrc = Dict{Symbol,Any}()
+    symsrc[:name] = "s"
+    symsrc[:amount] = 5
+    t1 = StructUtils.make(TTier, symsrc)
+    (t1::TTier).amount == 5 || error("symkey")
+    # Symbol-keyed source into an unregistered struct (the case
+    # make_trim_safe.jl previously exercised): reflection-only table
+    intsrc = Dict{Symbol,Any}()
+    intsrc[:a] = 1
+    intsrc[:b] = 2
+    ti = StructUtils.make(TInts, intsrc)
+    ti isa TInts || error("tints type")
+    (ti::TInts).a == 1 || error("tints a")
+    (ti::TInts).b == 2 || error("tints b")
+    # unregistered plain struct with mixed field types
+    plainsrc = Dict{String,Any}()
+    plainsrc["x"] = 1
+    plainsrc["y"] = "z"
+    p = StructUtils.make(TPlain, plainsrc)
+    p isa TPlain || error("plain type")
+    (p::TPlain).x == 1 || error("plain x")
+    (p::TPlain).y == "z" || error("plain y")
+    # required-field error path stays trim-clean and reachable
+    badsrc = Dict{String,Any}()
+    badsrc["amount"] = 1
+    threw = false
+    try
+        StructUtils.make(TTier, badsrc)
+    catch
+        threw = true
+    end
+    threw || error("required")
+    return nothing
+end
+
+function @main(args::Vector{String})::Cint
+    _ = args
+    run_interp_trim_sample()
+    Core.println("INTERP_TRIM_OK")
+    return 0
+end
+
+Base.Experimental.entrypoint(main, (Vector{String},))

--- a/test/make_trim_safe.jl
+++ b/test/make_trim_safe.jl
@@ -41,9 +41,9 @@ function run_make_trim_sample()::Nothing
     a.a == 1 || error("TrimA.a")
     a.d == 4 || error("TrimA.d")
 
-    # 2. Plain struct from Dict{Symbol,Int} (homogeneous value type)
-    a2 = StructUtils.make(TrimA, Dict{Symbol,Int}(:a => 1, :b => 2, :c => 3, :d => 4))
-    a2.a == 1 || error("TrimA Dict")
+    # 2. Plain struct from Dict{Symbol,Int}: tree-shaped sources route
+    # through the tier-0 interpreter, whose no-JIT graph requires the
+    # trim_build preference — exercised in interp_trim_safe.jl instead
 
     # 3. Struct with defaults — all provided
     b1 = StructUtils.make(TrimB, (a=1, b=2, c=3, d=4))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -45,6 +45,7 @@ include(joinpath(dirname(pathof(StructUtils)), "../test/macros.jl"))
 include(joinpath(dirname(pathof(StructUtils)), "../test/struct.jl"))
 include(joinpath(dirname(pathof(StructUtils)), "../test/selectors.jl"))
 include(joinpath(dirname(pathof(StructUtils)), "../test/interp.jl"))
+include(joinpath(dirname(pathof(StructUtils)), "../test/hot.jl"))
 
 @testset "StructUtils" begin
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -44,6 +44,7 @@ end
 include(joinpath(dirname(pathof(StructUtils)), "../test/macros.jl"))
 include(joinpath(dirname(pathof(StructUtils)), "../test/struct.jl"))
 include(joinpath(dirname(pathof(StructUtils)), "../test/selectors.jl"))
+include(joinpath(dirname(pathof(StructUtils)), "../test/interp.jl"))
 
 @testset "StructUtils" begin
 

--- a/test/trim_compile_tests.jl
+++ b/test/trim_compile_tests.jl
@@ -180,7 +180,14 @@ end
         println("[trim] skip prerelease Julia: trim verifier behavior is not stable yet")
         @test true
     else
+        # every trimmed app sets the trim_build preference — an app-level
+        # environment fact (one line of LocalPreferences, no per-type
+        # annotations): it prunes the make family's JIT-only arms, which is
+        # what keeps the static call graph verifier-resolvable now that the
+        # classic per-type closures are gone
         project_path = _setup_trim_env()
+        write(joinpath(project_path, "LocalPreferences.toml"),
+            "[StructUtils]\ntrim_build = true\n")
         trim_workloads = [
             ("make_trim_safe.jl", "make_trim_safe"),
             ("hot_trim_safe.jl", "hot_trim_safe"),
@@ -188,9 +195,8 @@ end
         for (script_file, output_name) in trim_workloads
             _run_trim_case(project_path, script_file, output_name)
         end
-        # tier-0 interpreter case: runs in its own env because the
-        # trim_build preference (which prunes the interpreter's JIT-only
-        # arms) keys StructUtils' precompile cache
+        # tier-0 interpreter case in a second fresh env: exercises a clean
+        # precompile of the preference-keyed package image
         interp_project = _setup_trim_env()
         write(joinpath(interp_project, "LocalPreferences.toml"),
             "[StructUtils]\ntrim_build = true\n")

--- a/test/trim_compile_tests.jl
+++ b/test/trim_compile_tests.jl
@@ -10,6 +10,9 @@ const _JULIAC_ENTRYPOINT_EXPR = "using JuliaC; if isdefined(JuliaC, :main); Juli
 # default load path.
 function _clean_cmd(cmd::Cmd)
     env = Dict{String,String}(k => v for (k, v) in ENV if k != "JULIA_LOAD_PATH")
+    # juliac sessions must not execute precompile workloads: they would bake
+    # JIT-only instances into the image for the verifier to reject
+    env["JULIAC_DISABLE_PRECOMPILE_WORKLOADS"] = "1"
     return setenv(cmd, env)
 end
 
@@ -180,6 +183,7 @@ end
         project_path = _setup_trim_env()
         trim_workloads = [
             ("make_trim_safe.jl", "make_trim_safe"),
+            ("hot_trim_safe.jl", "hot_trim_safe"),
         ]
         for (script_file, output_name) in trim_workloads
             _run_trim_case(project_path, script_file, output_name)

--- a/test/trim_compile_tests.jl
+++ b/test/trim_compile_tests.jl
@@ -184,5 +184,12 @@ end
         for (script_file, output_name) in trim_workloads
             _run_trim_case(project_path, script_file, output_name)
         end
+        # tier-0 interpreter case: runs in its own env because the
+        # trim_build preference (which prunes the interpreter's JIT-only
+        # arms) keys StructUtils' precompile cache
+        interp_project = _setup_trim_env()
+        write(joinpath(interp_project, "LocalPreferences.toml"),
+            "[StructUtils]\ntrim_build = true\n")
+        _run_trim_case(interp_project, "interp_trim_safe.jl", "interp_trim_safe")
     end
 end


### PR DESCRIPTION
## Two-tier `make`: tier-0 field-table interpreter by default, `:hot` opt-in, classic struct family deleted

Replaces the per-type-specializing classic struct construction with a two-tier architecture (design ratified in review; supersedes the `trim_specialize` Preference approach from #62):

- **Tier 0 (default): a field-table interpreter.** One engine instance per style — `@nospecialize`/`@nospecializeinfer` throughout, `FieldTable`/`FieldSpec`/`ValueSpec` metadata, `Memory{Any}` slots, `jl_new_structv`-style construction, a closed leaf ladder (incl. hand-rolled ISO Date/DateTime/Time parsers). Any target type, any tree-shaped source; per-type cost is a table build, not a compile. Covers structs, `@noarg` mutables (incl. `@atomic` fields), NamedTuples, tuples, dicts, sets, multidim arrays, unions, positional sources, aliases, parametric defaults, and stateful per-style metadata via volatile (rebuild-per-make) tables.
- **`:hot` opt-in**: `@kwarg :hot struct ...` (also `@defaults`/`@tags`/`@noarg`, or standalone `StructUtils.@hot`) keeps a fully specialized descent, compiled at the annotating package's precompile time via a hook registry + PrecompileTools (new dependency). Purely a TTFX/steady-perf feature.
- **Trim**: a trimmed app sets one app-level Preference (`trim_build = true`); it prunes the JIT-only arms so the static graph verifies. No per-type annotations required for trim correctness. Three JuliaC harness cases run in CI at a 0-error budget.
- **Classic deleted**: `makestruct`/`makenoarg`/`findfield`/`StructClosure` and the `treesafe` machinery are gone. Container machinery (`maketuple`/`makearray`/`makedict`) is retained and shared.

### Semantics preserved (each backed by a test that caught the gap)
positional `Vector`/`Tuple` → struct sources; pair-vectors as dictlike; classic `@_peel` null ordering (explicit null → `Missing` arm first); per-field public `fieldtags(style, T, field)`; `unknownfield` hooks for surplus positional elements; user `make` overloads and style-level `dictlike`/`arraylike` overrides classify CUSTOM (the interpreter never bypasses user hooks); the hot closures now route custom-make field types through 4-arg `make` dispatch (classic behavior the hot tier previously lacked).

### Compiler landmines encoded as structure (see commit messages for detail)
- Constant-foldable source-trait checks inside the recursive make family send constprop/irinterp into a non-terminating compile: verdicts live behind `@nospecializeinfer` boundaries.
- Generated-function generators run in a frozen world: the custom-make verdict is a runtime-world memo riding the closure, never generator-time reflection.
- `Type{<:T}` method queries intersect every `where S<:Other` method through `Type{Union{}}`: queries use the concrete `Type{T}`.

### Numbers (measured on the JSON integration, 216-case seeded fuzz vs JSON 1.4.0 + StructUtils 2.6.2)
first-parse sum 48.1s vs 77.1s (1.6× faster cold); steady parse geomean 1.80× (request-shaped 3.6×); accepted losses on bulk-vector docs/containers (the interpreter vs a compiled descent — `:hot` recovers those); results value-identical across the corpus.

Suite: full tests green including the three trim-compile cases. Downstream: JuliaIO/JSON.jl PR (companion) and a league-easy adoption PR validate end-to-end, including a 29MB trimmed server binary at 0 verifier errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
