### PR TITLE
Fix root lowering for non-struct mappings

### DIFF
--- a/src/StructUtils.jl
+++ b/src/StructUtils.jl
@@ -957,15 +957,23 @@ function make(style::StructStyle, T::Type, source)
         end
     end
     if T <: Tuple
-        return maketuple(style, T, source)
+        return maketuple(style, T, lower(style, source))
     elseif dictlike(style, T)
-        return makedict(style, T, source)
+        lowered = lower(style, source)
+        if abstractcollectionpassthrough(style, T, lowered)
+            return lowered, defaultstate(style)
+        end
+        return makedict(style, T, lowered)
     elseif arraylike(style, T)
-        return makearray(style, T, source)
+        lowered = lower(style, source)
+        if abstractcollectionpassthrough(style, T, lowered)
+            return lowered, defaultstate(style)
+        end
+        return makearray(style, T, lowered)
     elseif noarg(style, T)
-        return makenoarg(style, T, source)
+        return makenoarg(style, T, lower(style, source))
     elseif structlike(style, T)
-        return makestruct(style, T, source)
+        return makestruct(style, T, lower(style, source))
     else
         return lift(style, T, source)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -408,6 +408,46 @@ end
     @test !StructUtils.structlike(StructUtils.DefaultStyle(), NonStructComplex)
 end
 
+@testset "@nonstruct representation in make: #29" begin
+    mapping = Dict{String,Any}("leaf" => 1)
+    value = NonStructMapping(mapping)
+
+    # Root values use the same representation as values nested in a source.
+    @test StructUtils.make(Dict{String,Any}, value) == mapping
+    @test StructUtils.make(NonStructMappingTarget, value) == NonStructMappingTarget(1)
+
+    @test StructUtils.make(
+        Dict{String,Any},
+        NonStructMappingHolder(value),
+    ) == Dict{String,Any}("value" => mapping)
+    @test StructUtils.make(Vector{Any}, Any[value]) == Any[mapping]
+    @test StructUtils.make(
+        Dict{String,Any},
+        Dict{String,Any}("value" => value),
+    ) == Dict{String,Any}("value" => mapping)
+
+    # Lowering may produce a concrete value satisfying an abstract target.
+    @test StructUtils.make(AbstractDict, value) === mapping
+    @test StructUtils.make(
+        AbstractNonStructMappingTarget,
+        value,
+    ) == ConcreteNonStructMappingTarget(1)
+
+    # Style-specific lowering is honored exactly once at the root.
+    style = NonStructMappingStyle(0)
+    @test StructUtils.make(Dict{String,Any}, value, style) == mapping
+    @test style.lower_calls == 1
+
+    # A target-owned make hook still receives the raw source.
+    hook_style = NonStructMappingStyle(0)
+    made = StructUtils.make(NonStructCustomMakeTarget, value, hook_style)
+    @test made.saw_raw_source
+    @test hook_style.lower_calls == 0
+
+    # Making a non-struct target continues to use lift on the raw source.
+    @test StructUtils.make(NonStructMapping, mapping).value === mapping
+end
+
 @testset "Set make: #13" begin
     @test StructUtils.make(Set{Symbol}, Any["FACTOR"]) == Set{Symbol}([:FACTOR])
 end

--- a/test/struct.jl
+++ b/test/struct.jl
@@ -231,6 +231,53 @@ end
     data::String
 end
 
+@nonstruct struct NonStructMapping
+    value::Any
+end
+
+StructUtils.lift(::Type{NonStructMapping}, value) = NonStructMapping(value)
+StructUtils.lower(value::NonStructMapping) = value.value
+
+struct NonStructMappingHolder
+    value::NonStructMapping
+end
+
+struct NonStructMappingTarget
+    leaf::Int
+end
+
+abstract type AbstractNonStructMappingTarget end
+
+struct ConcreteNonStructMappingTarget <: AbstractNonStructMappingTarget
+    leaf::Int
+end
+
+StructUtils.@choosetype AbstractNonStructMappingTarget source -> begin
+    source isa NonStructMapping || error("expected the raw non-struct source")
+    ConcreteNonStructMappingTarget
+end
+
+mutable struct NonStructMappingStyle <: StructUtils.StructStyle
+    lower_calls::Int
+end
+
+function StructUtils.lower(style::NonStructMappingStyle, value::NonStructMapping)
+    style.lower_calls += 1
+    return value.value
+end
+
+struct NonStructCustomMakeTarget
+    saw_raw_source::Bool
+end
+
+function StructUtils.make(
+    style::NonStructMappingStyle,
+    ::Type{NonStructCustomMakeTarget},
+    source::NonStructMapping,
+)
+    return NonStructCustomMakeTarget(true), StructUtils.defaultstate(style)
+end
+
 struct Q
     id::Int
     value::MIME


### PR DESCRIPTION
Root cause: `make` lowered nested values through `applyeach`, but passed root sources directly to structural builders. `@nonstruct` roots were therefore traversed as structs and exposed private fields.

Fix: lower root sources before tuple, dictionary, array, no-argument, and struct builders, then re-run abstract collection pass-through after lowering. Atom targets and custom `make` methods still receive the raw source.

Co-authored by Codex