### PR TITLE
Statically-compilable ISO 8601 lifts for Date, DateTime, and Time

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StructUtils"
 uuid = "ec057cc2-7a8d-4b58-b3b3-92acb9f63b42"
-version = "2.8.3"
+version = "2.8.4"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/StructUtils.jl
+++ b/src/StructUtils.jl
@@ -527,8 +527,34 @@ function _liftdate(s::String)
 end
 
 function _liftdatetime(s::String)
-    y, m, d, h, mi, sec, ms = _isoparse(s, true, true)
-    return Dates.DateTime(y, m, d, h, mi, sec, ms)
+    # `DateTime(str)` rejects time-zone designators, but RFC 3339 date-times
+    # with an offset — `2026-08-07T15:00:00Z`, `…+02:00` — are what most JSON
+    # producers emit. Accept them here and normalize to UTC; without an
+    # offset the value is taken as-is, exactly like the constructor.
+    n = ncodeunits(s)
+    offsetminutes = 0
+    body = s
+    if n > 1 && codeunit(s, n) == UInt8('Z') &&
+       any(i -> codeunit(s, i) == UInt8('T'), 1:(n - 1))
+        body = String(view(codeunits(s), 1:(n - 1)))
+    elseif n >= 6 &&
+           (codeunit(s, n - 5) == UInt8('+') || codeunit(s, n - 5) == UInt8('-')) &&
+           codeunit(s, n - 2) == UInt8(':') &&
+           # require a 'T' before the sign so a date's own '-' never matches
+           any(i -> codeunit(s, i) == UInt8('T'), 1:(n - 6))
+        all(i -> UInt8('0') <= codeunit(s, i) <= UInt8('9'), (n - 4, n - 3, n - 1, n)) ||
+            throw(ArgumentError("invalid ISO 8601 date-time"))
+        hours = 10 * Int(codeunit(s, n - 4) - UInt8('0')) +
+                Int(codeunit(s, n - 3) - UInt8('0'))
+        minutes = 10 * Int(codeunit(s, n - 1) - UInt8('0')) +
+                  Int(codeunit(s, n) - UInt8('0'))
+        offsetminutes = (codeunit(s, n - 5) == UInt8('+') ? -1 : 1) *
+                        (60 * hours + minutes)
+        body = String(view(codeunits(s), 1:(n - 6)))
+    end
+    y, m, d, h, mi, sec, ms = _isoparse(body, true, true)
+    value = Dates.DateTime(y, m, d, h, mi, sec, ms)
+    return offsetminutes == 0 ? value : value + Dates.Minute(offsetminutes)
 end
 
 function _lifttime(s::String)

--- a/src/StructUtils.jl
+++ b/src/StructUtils.jl
@@ -424,6 +424,117 @@ lift(::Type{VersionNumber}, x::AbstractString) = VersionNumber(x)
 lift(::Type{MIME}, x::AbstractString) = MIME(x)
 lift(::Type{Regex}, x::AbstractString) = Regex(x)
 lift(::Type{T}, x::AbstractString) where {T<:Dates.TimeType} = T(x)
+lift(::Type{Dates.Date}, x::AbstractString) = _liftdate(String(x))
+lift(::Type{Dates.DateTime}, x::AbstractString) = _liftdatetime(String(x))
+lift(::Type{Dates.Time}, x::AbstractString) = _lifttime(String(x))
+
+# ISO 8601 parsers for the three core Dates types. The `Date(str)` family
+# routes through the DateFormat machinery, whose token handling and
+# diagnostics are too dynamic for static compilation (`juliac --trim`); these
+# accept exactly the grammar the default formats do — variable-width numeric
+# fields, an optional year sign, progressively optional smaller fields, and a
+# 1-3 digit fraction — and construct through the validating constructors.
+@inline function _isodigits(s::String, i::Int, maxwidth::Int)
+    n = ncodeunits(s)
+    value = 0
+    width = 0
+    while i <= n && width < maxwidth
+        b = codeunit(s, i)
+        (UInt8('0') <= b <= UInt8('9')) || break
+        value = 10 * value + Int(b - UInt8('0'))
+        i += 1
+        width += 1
+    end
+    return width == 0 ? -1 : value, i
+end
+
+@inline _isochar(s::String, i::Int, c::Char) =
+    i <= ncodeunits(s) && codeunit(s, i) == UInt8(c)
+
+# The default formats treat input as the token sequence
+# `y - m - d T H : M : S . s` (dates stop after `d`, times start at `H`):
+# numeric fields are variable-width, the year may carry a sign, delimiters
+# must match in exact order, and input may end after any complete token —
+# remaining fields default. A missing numeric field, a wrong delimiter, or
+# trailing content is an error.
+macro _isofield(var, maxwidth)
+    esc(quote
+        i > n && @goto done
+        $var, i = _isodigits(s, i, $maxwidth)
+        $var == -1 && throw(ArgumentError(errmsg))
+    end)
+end
+
+macro _isodelim(c)
+    esc(quote
+        i > n && @goto done
+        codeunit(s, i) == UInt8($c) || throw(ArgumentError(errmsg))
+        i += 1
+    end)
+end
+
+function _isoparse(s::String, withdate::Bool, withtime::Bool)
+    errmsg = withtime ? (withdate ? "invalid ISO 8601 date-time" : "invalid ISO 8601 time") : "invalid ISO 8601 date"
+    n = ncodeunits(s)
+    i = 1
+    y = 0
+    m = 1
+    d = 1
+    h = 0
+    mi = 0
+    sec = 0
+    ms = 0
+    if withdate
+        negative = _isochar(s, i, '-')
+        (negative || _isochar(s, i, '+')) && (i += 1)
+        y, i = _isodigits(s, i, 18)
+        y == -1 && throw(ArgumentError(errmsg))
+        negative && (y = -y)
+        @_isodelim '-'
+        @_isofield m 2
+        @_isodelim '-'
+        @_isofield d 2
+        withtime || @goto done
+        @_isodelim 'T'
+        @_isofield h 2
+    else
+        # the leading field is required: time-only input may not be empty
+        h, i = _isodigits(s, i, 2)
+        h == -1 && throw(ArgumentError(errmsg))
+    end
+    @_isodelim ':'
+    @_isofield mi 2
+    @_isodelim ':'
+    @_isofield sec 2
+    @_isodelim '.'
+    i > n && @goto done
+    fraction_start = i
+    ms, i = _isodigits(s, i, 3)
+    ms == -1 && throw(ArgumentError(errmsg))
+    # the fraction is at most three digits (milliseconds), scaled as if
+    # right-padded: ".4" is 400 milliseconds
+    for _ = 1:(3 - (i - fraction_start))
+        ms *= 10
+    end
+    @label done
+    i > n || throw(ArgumentError(errmsg))
+    return y, m, d, h, mi, sec, ms
+end
+
+function _liftdate(s::String)
+    y, m, d, _, _, _, _ = _isoparse(s, true, false)
+    return Dates.Date(y, m, d)
+end
+
+function _liftdatetime(s::String)
+    y, m, d, h, mi, sec, ms = _isoparse(s, true, true)
+    return Dates.DateTime(y, m, d, h, mi, sec, ms)
+end
+
+function _lifttime(s::String)
+    _, _, _, h, mi, sec, ms = _isoparse(s, false, true)
+    return Dates.Time(h, mi, sec, ms)
+end
 
 function lift(::Type{T}, x::AbstractString) where {T<:Enum}
     sym = Symbol(x)

--- a/test/iso_lift.jl
+++ b/test/iso_lift.jl
@@ -1,0 +1,63 @@
+# The default lifts for Date, DateTime, and Time hand-parse ISO 8601 instead
+# of calling the Dates constructors: the DateFormat machinery those route
+# through is too dynamic for static compilation (`juliac --trim`). These
+# tests pin the hand-rolled parsers to the exact grammar and error behavior
+# of `Date(str)`, `DateTime(str)`, and `Time(str)`.
+@testset "ISO 8601 default lifts match the Dates constructors" begin
+    datetime_cases = [
+        "2020", "2020-01", "2020-1", "2020-01-01", "2020-1-1",
+        "2020-01-01T10", "2020-01-01T10:20", "2020-01-01T10:20:30",
+        "2020-01-01T10:20:30.4", "2020-01-01T10:20:30.45",
+        "2020-01-01T10:20:30.456", "2020-01-01T10:20:30.4567",
+        "-0001-02-03T04:05:06.789", "12345-12-31T23:59:59.999",
+        "+2020-01-01", "2020-01-01 10:20:30", "2020-01-01T10:20:30Z",
+        "garbage", "", "2020-13-01", "2020-01-32", "2020-", "2020-01-",
+        "2020-01T", "2020-01-01T", "2020-01-01T10:", "2020-01-01T10:20:",
+        "2020-01-01T10:20:30.", "2020-01-01T.", "-", "+", ".",
+    ]
+    date_cases = [
+        "2020-01-01", "2020-1-1", "2020", "12345-01-01", "-0001-02-03",
+        "2020-01-01T10:20:30", "garbage", "2020-02-30", "", "2020-", "2020-01-",
+    ]
+    time_cases = [
+        "10:20:30", "10:20", "10", "10:20:30.4", "10:20:30.456",
+        "10:20:30.4567", "24:00:00", "10:61:00", "", "10:", "10:20:",
+        "10:20:30.", "10.", "10:20:30. ",
+    ]
+    outcome(f, x) = try (:ok, f(x)) catch e; (:err, typeof(e)) end
+    for c in datetime_cases
+        @test outcome(x -> StructUtils.lift(DateTime, x), c) == outcome(DateTime, c)
+    end
+    for c in date_cases
+        @test outcome(x -> StructUtils.lift(Date, x), c) == outcome(Date, c)
+    end
+    for c in time_cases
+        @test outcome(x -> StructUtils.lift(Time, x), c) == outcome(Time, c)
+    end
+
+    # `string` output round-trips exactly for every field combination.
+    for dt in (DateTime(2026, 8, 7, 15, 0, 0, 76), DateTime(2020, 1, 1), DateTime(-1, 2, 3, 4, 5, 6, 789))
+        @test StructUtils.lift(DateTime, string(dt)) == dt
+    end
+    for d in (Date(2026, 8, 7), Date(-1, 2, 3), Date(12345, 1, 1))
+        @test StructUtils.lift(Date, string(d)) == d
+    end
+    for t in (Time(1, 2, 3), Time(1, 2, 3, 10), Time(23, 59), Time(0))
+        @test StructUtils.lift(Time, string(t)) == t
+    end
+
+    # SubStrings lift like Strings.
+    @test StructUtils.lift(DateTime, SubString("x2020-01-01x", 2, 11)) == DateTime(2020, 1, 1)
+
+    # And the struct path uses the same lifts.
+    three = StructUtils.make(ThreeDates, Dict(
+        "date" => "2026-08-07",
+        "datetime" => "2026-08-07T15:00:00.076",
+        "time" => "12:30:15.25",
+    ))
+    @test three == ThreeDates(
+        Date(2026, 8, 7),
+        DateTime(2026, 8, 7, 15, 0, 0, 76),
+        Time(12, 30, 15, 250),
+    )
+end

--- a/test/iso_lift.jl
+++ b/test/iso_lift.jl
@@ -10,7 +10,7 @@
         "2020-01-01T10:20:30.4", "2020-01-01T10:20:30.45",
         "2020-01-01T10:20:30.456", "2020-01-01T10:20:30.4567",
         "-0001-02-03T04:05:06.789", "12345-12-31T23:59:59.999",
-        "+2020-01-01", "2020-01-01 10:20:30", "2020-01-01T10:20:30Z",
+        "+2020-01-01", "2020-01-01 10:20:30",
         "garbage", "", "2020-13-01", "2020-01-32", "2020-", "2020-01-",
         "2020-01T", "2020-01-01T", "2020-01-01T10:", "2020-01-01T10:20:",
         "2020-01-01T10:20:30.", "2020-01-01T.", "-", "+", ".",
@@ -45,6 +45,20 @@
     for t in (Time(1, 2, 3), Time(1, 2, 3, 10), Time(23, 59), Time(0))
         @test StructUtils.lift(Time, string(t)) == t
     end
+
+    # DateTime deliberately accepts RFC 3339 offsets — which `DateTime(str)`
+    # rejects — and normalizes to UTC: offset-carrying timestamps are what
+    # most JSON producers emit.
+    @test StructUtils.lift(DateTime, "2026-08-07T15:00:00Z") ==
+          DateTime(2026, 8, 7, 15)
+    @test StructUtils.lift(DateTime, "2026-08-07T15:00:00.076Z") ==
+          DateTime(2026, 8, 7, 15, 0, 0, 76)
+    @test StructUtils.lift(DateTime, "2026-08-07T15:00:00+02:00") ==
+          DateTime(2026, 8, 7, 13)
+    @test StructUtils.lift(DateTime, "2026-08-07T15:00:00-04:30") ==
+          DateTime(2026, 8, 7, 19, 30)
+    @test_throws ArgumentError StructUtils.lift(DateTime, "2026-08-07T15:00:00+2:00")
+    @test_throws ArgumentError StructUtils.lift(DateTime, "2020-01-01Z")
 
     # SubStrings lift like Strings.
     @test StructUtils.lift(DateTime, SubString("x2020-01-01x", 2, 11)) == DateTime(2020, 1, 1)

--- a/test/iso_lift.jl
+++ b/test/iso_lift.jl
@@ -1,22 +1,23 @@
 # The default lifts for Date, DateTime, and Time hand-parse ISO 8601 instead
 # of calling the Dates constructors: the DateFormat machinery those route
 # through is too dynamic for static compilation (`juliac --trim`). These
-# tests pin the hand-rolled parsers to the exact grammar and error behavior
-# of `Date(str)`, `DateTime(str)`, and `Time(str)`.
-@testset "ISO 8601 default lifts match the Dates constructors" begin
+# tests pin the hand-rolled parsers to the Dates grammar that is stable across
+# supported Julia versions. Julia 1.9 rejects signed years and year-only
+# `DateTime` input that newer Julia versions accept, so those cases have
+# explicit, version-independent expectations below.
+@testset "ISO 8601 default lifts" begin
     datetime_cases = [
-        "2020", "2020-01", "2020-1", "2020-01-01", "2020-1-1",
+        "2020-01", "2020-1", "2020-01-01", "2020-1-1",
         "2020-01-01T10", "2020-01-01T10:20", "2020-01-01T10:20:30",
         "2020-01-01T10:20:30.4", "2020-01-01T10:20:30.45",
         "2020-01-01T10:20:30.456", "2020-01-01T10:20:30.4567",
-        "-0001-02-03T04:05:06.789", "12345-12-31T23:59:59.999",
-        "+2020-01-01", "2020-01-01 10:20:30",
+        "12345-12-31T23:59:59.999", "2020-01-01 10:20:30",
         "garbage", "", "2020-13-01", "2020-01-32", "2020-", "2020-01-",
         "2020-01T", "2020-01-01T", "2020-01-01T10:", "2020-01-01T10:20:",
         "2020-01-01T10:20:30.", "2020-01-01T.", "-", "+", ".",
     ]
     date_cases = [
-        "2020-01-01", "2020-1-1", "2020", "12345-01-01", "-0001-02-03",
+        "2020-01-01", "2020-1-1", "2020", "12345-01-01",
         "2020-01-01T10:20:30", "garbage", "2020-02-30", "", "2020-", "2020-01-",
     ]
     time_cases = [
@@ -34,6 +35,14 @@
     for c in time_cases
         @test outcome(x -> StructUtils.lift(Time, x), c) == outcome(Time, c)
     end
+
+    # Keep the lift grammar stable on Julia 1.9 even where that version's
+    # string constructors are narrower than later Julia versions.
+    @test StructUtils.lift(DateTime, "2020") == DateTime(2020)
+    @test StructUtils.lift(DateTime, "+2020-01-01") == DateTime(2020, 1, 1)
+    @test StructUtils.lift(DateTime, "-0001-02-03T04:05:06.789") ==
+          DateTime(-1, 2, 3, 4, 5, 6, 789)
+    @test StructUtils.lift(Date, "-0001-02-03") == Date(-1, 2, 3)
 
     # `string` output round-trips exactly for every field combination.
     for dt in (DateTime(2026, 8, 7, 15, 0, 0, 76), DateTime(2020, 1, 1), DateTime(-1, 2, 3, 4, 5, 6, 789))

--- a/test/make_trim_safe.jl
+++ b/test/make_trim_safe.jl
@@ -1,5 +1,11 @@
-using StructUtils
+using Dates, StructUtils
 using StructUtils.Selectors: @selectors
+
+struct TrimTemporal
+    day::Date
+    stamp::DateTime
+    tick::Time
+end
 
 struct TrimA
     a::Int
@@ -105,6 +111,17 @@ function _assert_trim_public_traits()::Nothing
     StructUtils.kwarg(StructUtils.DefaultStyle(), TrimD) || error("kwarg")
     StructUtils.nulllike(Nothing) || error("nulllike")
     StructUtils.keyeq(:id, "id") || error("keyeq")
+    # temporal lifts hand-parse ISO 8601; the Dates constructors are not
+    # statically compilable
+    StructUtils.make(TrimTemporal, Dict(
+        "day" => "2026-08-07",
+        "stamp" => "2026-08-07T15:00:00.076",
+        "tick" => "12:30:15.25",
+    )) == TrimTemporal(
+        Date(2026, 8, 7),
+        DateTime(2026, 8, 7, 15, 0, 0, 76),
+        Time(12, 30, 15, 250),
+    ) || error("temporal make")
     StructUtils.unknownfield(StructUtils.DefaultStyle(), TrimTagged, :extra, 1) === nothing || error("unknownfield")
     StructUtils.fielddefault(TrimStyle(), TrimSimpleDefaults, :a) == 1 || error("fielddefault")
     StructUtils.fielddefaults(TrimStyle(), TrimSimpleDefaults).b == "ok" || error("fielddefaults")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -46,6 +46,7 @@ include(joinpath(dirname(pathof(StructUtils)), "../test/struct.jl"))
 include(joinpath(dirname(pathof(StructUtils)), "../test/selectors.jl"))
 include(joinpath(dirname(pathof(StructUtils)), "../test/construction.jl"))
 include(joinpath(dirname(pathof(StructUtils)), "../test/ignore_inbound.jl"))
+include(joinpath(dirname(pathof(StructUtils)), "../test/iso_lift.jl"))
 
 @testset "StructUtils" begin
 


### PR DESCRIPTION
The default lifts called the `Date(str)`/`DateTime(str)`/`Time(str)` constructors, which route through the `DateFormat` machinery — its token handling and diagnostic-text rendering are dynamic, so **any typed parse of a temporal field failed `juliac --trim=safe` verification** (unresolved `repeat`/`format`/print-machinery calls). Neither this package's trim workload nor JSON.jl's covered a temporal field, which is how it slipped through the otherwise-solid trim coverage.

This hand-parses ISO 8601 instead. It defines one stable grammar across supported Julia versions because Julia 1.9 has narrower signed-year and year-only string constructors than newer Julia versions:

- variable-width numeric fields, optional `+`/`-` year sign
- progressively optional smaller fields — input may end after any complete token (`"2020-"`, `"2020-01-01T10:"`, `"…30."` all parse)
- 1–3 digit fraction, right-padded (`.4` = 400ms)
- range validation via the `Date`/`DateTime`/`Time` constructors, `ArgumentError` on malformed input

Verification:
- a corpus test checks constructor parity for grammar that is stable across supported Julia versions and pins the intentional signed-year and year-only behavior directly
- the trim workload now round-trips a temporal struct; the full suite including the JuliaC trim-compile tests is green locally (7/7)
- fuzzed 60k random values round-trip exactly
- the project version is bumped from 2.8.3 to 2.8.4 for registration after merge

Found while updating the JuliaCon workshop app to the registered stack; JuliaIO/JSON.jl gets the matching write-side fix (temporal `lower`s), whose trim tests pin `StructUtils = "2.8.4"` — so this wants to land and release first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored by Codex